### PR TITLE
fix: Python floats and ints are now transmitted with 64-bit precision instead of 32.

### DIFF
--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -546,7 +546,7 @@ cdef class Buffer:
     cdef inline int _column_ts(
             self, line_sender_column_name c_name, TimestampMicros ts) except -1:
         cdef line_sender_error* err = NULL
-        if not line_sender_buffer_column_ts(self._impl, c_name, ts.value, &err):
+        if not line_sender_buffer_column_ts(self._impl, c_name, ts._value, &err):
             raise c_err_to_py(err)
         return 0
 
@@ -594,7 +594,7 @@ cdef class Buffer:
 
     cdef inline int _at_ts(self, TimestampNanos ts) except -1:
         cdef line_sender_error* err = NULL
-        if not line_sender_buffer_at(self._impl, ts.value, &err):
+        if not line_sender_buffer_at(self._impl, ts._value, &err):
             raise c_err_to_py(err)
         return 0
 

--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -35,6 +35,9 @@ from cpython.datetime cimport datetime
 from cpython.bool cimport bool, PyBool_Check
 from cpython.weakref cimport PyWeakref_NewRef, PyWeakref_GetObject
 from cpython.object cimport PyObject
+from cpython.float cimport PyFloat_Check
+from cpython.int cimport PyInt_Check
+from cpython.unicode cimport PyUnicode_Check
 
 from .line_sender cimport *
 
@@ -527,7 +530,7 @@ cdef class Buffer:
         return 0
 
     cdef inline int _column_f64(
-            self, line_sender_column_name c_name, float value) except -1:
+            self, line_sender_column_name c_name, double value) except -1:
         cdef line_sender_error* err = NULL
         if not line_sender_buffer_column_f64(self._impl, c_name, value, &err):
             raise c_err_to_py(err)
@@ -562,11 +565,11 @@ cdef class Buffer:
         cdef bytes owner_name = str_to_column_name(name, &c_name)
         if PyBool_Check(value):
             return self._column_bool(c_name, value)
-        elif isinstance(value, int):
+        elif PyInt_Check(value):
             return self._column_i64(c_name, value)
-        elif isinstance(value, float):
+        elif PyFloat_Check(value):
             return self._column_f64(c_name, value)
-        elif isinstance(value, str):
+        elif PyUnicode_Check(value):
             return self._column_str(c_name, value)
         elif isinstance(value, TimestampMicros):
             return self._column_ts(c_name, value)

--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -30,7 +30,7 @@
 API for fast data ingestion into QuestDB.
 """
 
-from libc.stdint cimport uint8_t, int64_t
+from libc.stdint cimport uint8_t, uint64_t, int64_t
 from cpython.datetime cimport datetime
 from cpython.bool cimport bool, PyBool_Check
 from cpython.weakref cimport PyWeakref_NewRef, PyWeakref_GetObject
@@ -521,9 +521,7 @@ cdef class Buffer:
         return 0
 
     cdef inline int _column_i64(
-            self, line_sender_column_name c_name, int value) except -1:
-        # TODO: Generally audit for int overflows this in the whole codebase.
-        # We pretty certainly have one here :-).
+            self, line_sender_column_name c_name, int64_t value) except -1:
         cdef line_sender_error* err = NULL
         if not line_sender_buffer_column_i64(self._impl, c_name, value, &err):
             raise c_err_to_py(err)
@@ -1081,9 +1079,9 @@ cdef class Sender:
             str interface=None,
             tuple auth=None,
             object tls=False,
-            int read_timeout=15000,
-            int init_capacity=65536,  # 64KiB
-            int max_name_len=127,
+            uint64_t read_timeout=15000,
+            uint64_t init_capacity=65536,  # 64KiB
+            uint64_t max_name_len=127,
             object auto_flush=64512):  # 63KiB
         cdef line_sender_error* err = NULL
 
@@ -1121,9 +1119,9 @@ cdef class Sender:
         self._impl = NULL
         self._buffer = None
 
-        if isinstance(port, int):
+        if PyInt_Check(port):
             port_str = str(port)
-        elif isinstance(port, str):
+        elif PyUnicode_Check(port):
             port_str = port
         else:
             raise TypeError(

--- a/test/test.py
+++ b/test/test.py
@@ -109,6 +109,11 @@ class TestBuffer(unittest.TestCase):
         buf.row('tbl1', symbols={'questdb1': '❤️'}, columns={'questdb2': '❤️'})
         self.assertEqual(str(buf), 'tbl1,questdb1=❤️ questdb2="❤️"\n')
 
+    def test_float(self):
+        buf = qi.Buffer()
+        buf.row('tbl1', columns={'num': 1.2345678901234567})
+        self.assertEqual(str(buf), f'tbl1 num=1.2345678901234567\n')
+
 
 class TestSender(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
Closes https://github.com/questdb/py-questdb-client/issues/13.