### PR TITLE
docs: fix readthedocs.io config with new required keys

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,9 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"  # latest 3.x CPython release
 sphinx:
   configuration: docs/conf.py
 formats: all


### PR DESCRIPTION
The [`build.os`](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os) field is now mandatory in the `.readthedocs.yml` configuration.