### PR TITLE
feat: Sender(..., tls=True) now also uses OS-provided certificate store.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,11 @@ def ingress_extension():
     if PLATFORM == 'darwin':
         lib_prefix = 'lib'
         lib_suffix = '.a'
-        extra_link_args.extend(['-framework', 'Security'])
+        extra_link_args.extend(['-framework', 'Security', '-framework', 'CoreFoundation'])
     elif PLATFORM == 'win32':
         lib_prefix = ''
         lib_suffix = '.lib'
-        libraries.extend(['wsock32', 'ws2_32', 'ntdll', 'AdvAPI32', 'bcrypt', 'UserEnv'])
+        libraries.extend(['wsock32', 'ws2_32', 'ntdll', 'AdvAPI32', 'bcrypt', 'UserEnv', 'crypt32', 'Secur32', 'NCrypt'])
     elif PLATFORM == 'linux':
         lib_prefix = 'lib'
         lib_suffix = '.a'

--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -1295,13 +1295,13 @@ cdef class Sender:
     * A ``str`` or ``pathlib.Path``: Path to a PEM-encoded certificate authority
       file. This is useful for testing with self-signed certificates.
 
-    * The special ``'os_certs'`` string: Use the OS-provided certificate store.
+    * The special ``'os_roots'`` string: Use the OS-provided certificate store.
 
-    * The special ``'webpki'`` string: Use the `webpki-roots
+    * The special ``'webpki_roots'`` string: Use the `webpki-roots
       <https://crates.io/crates/webpki-roots>`_ Rust crate to recognize
       certificates.
 
-    * The special ``'webpki_and_os_certs'`` string: Use both the `webpki-roots
+    * The special ``'webpki_and_os_roots'`` string: Use both the `webpki-roots
       <https://crates.io/crates/webpki-roots>`_ Rust crate and the OS-provided
       certificate store to recognize certificates. (equivalent to `True`).
 
@@ -1444,14 +1444,14 @@ cdef class Sender:
 
         if tls:
             if tls is True:
-                line_sender_opts_tls_webpki_and_os_certs(self._opts)
+                line_sender_opts_tls_webpki_and_os_roots(self._opts)
             elif isinstance(tls, str):
-                if tls == 'webpki':
+                if tls == 'webpki_roots':
                     line_sender_opts_tls(self._opts)
-                elif tls == 'os_certs':
-                    line_sender_opts_tls_os_certs(self._opts)
-                elif tls == 'webpki_and_os_certs':
-                    line_sender_opts_tls_webpki_and_os_certs(self._opts)
+                elif tls == 'os_roots':
+                    line_sender_opts_tls_os_roots(self._opts)
+                elif tls == 'webpki_and_os_roots':
+                    line_sender_opts_tls_webpki_and_os_roots(self._opts)
                 elif tls == 'insecure_skip_verify':
                     line_sender_opts_tls_insecure_skip_verify(self._opts)
                 else:

--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -1297,7 +1297,7 @@ cdef class Sender:
 
     * The special ``'os_certs'`` string: Use the OS-provided certificate store.
 
-    * The special ``'webpki_roots'`` string: Use the `webpki-roots
+    * The special ``'webpki'`` string: Use the `webpki-roots
       <https://crates.io/crates/webpki-roots>`_ Rust crate to recognize
       certificates.
 
@@ -1451,7 +1451,7 @@ cdef class Sender:
                 elif tls == 'os_certs':
                     line_sender_opts_tls_os_certs(self._opts)
                 elif tls == 'webpki_and_os_certs':
-                    line_sender_opts_tls_webpki_and_os_certs
+                    line_sender_opts_tls_webpki_and_os_certs(self._opts)
                 elif tls == 'insecure_skip_verify':
                     line_sender_opts_tls_insecure_skip_verify(self._opts)
                 else:

--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -1288,13 +1288,24 @@ cdef class Sender:
     * ``False``: No TLS encryption (default).
 
     * ``True``: TLS encryption, accepting all common certificates as recognized
-      by the `webpki-roots <https://crates.io/crates/webpki-roots>`_ Rust crate
-      which in turn relies on https://mkcert.org/.
+      by either the `webpki-roots <https://crates.io/crates/webpki-roots>`_ Rust
+      crate (which in turn relies on https://mkcert.org/), or the OS-provided
+      certificate store.
 
     * A ``str`` or ``pathlib.Path``: Path to a PEM-encoded certificate authority
       file. This is useful for testing with self-signed certificates.
 
-    * A special ``'insecure_skip_verify'`` string: Dangerously disable all
+    * The special ``'os_certs'`` string: Use the OS-provided certificate store.
+
+    * The special ``'webpki_roots'`` string: Use the `webpki-roots
+      <https://crates.io/crates/webpki-roots>`_ Rust crate to recognize
+      certificates.
+
+    * The special ``'webpki_and_os_certs'`` string: Use both the `webpki-roots
+      <https://crates.io/crates/webpki-roots>`_ Rust crate and the OS-provided
+      certificate store to recognize certificates. (equivalent to `True`).
+
+    * The special ``'insecure_skip_verify'`` string: Dangerously disable all
       TLS certificate verification (do *NOT* use in production environments).
 
     **Positional constructor arguments for the Sender(..)**
@@ -1433,9 +1444,15 @@ cdef class Sender:
 
         if tls:
             if tls is True:
-                line_sender_opts_tls(self._opts)
+                line_sender_opts_tls_webpki_and_os_certs(self._opts)
             elif isinstance(tls, str):
-                if tls == 'insecure_skip_verify':
+                if tls == 'webpki':
+                    line_sender_opts_tls(self._opts)
+                elif tls == 'os_certs':
+                    line_sender_opts_tls_os_certs(self._opts)
+                elif tls == 'webpki_and_os_certs':
+                    line_sender_opts_tls_webpki_and_os_certs
+                elif tls == 'insecure_skip_verify':
                     line_sender_opts_tls_insecure_skip_verify(self._opts)
                 else:
                     str_to_utf8(b, <PyObject*>tls, &ca_utf8)

--- a/src/questdb/line_sender.pxd
+++ b/src/questdb/line_sender.pxd
@@ -103,6 +103,10 @@ cdef extern from "questdb/ingress/line_sender.h":
 
   void line_sender_opts_tls(line_sender_opts *opts) noexcept nogil
 
+  void line_sender_opts_tls_os_certs(line_sender_opts *opts) noexcept nogil
+
+  void line_sender_opts_tls_webpki_and_os_certs(line_sender_opts *opts) noexcept nogil
+
   void line_sender_opts_tls_ca(line_sender_opts *opts, line_sender_utf8 ca_path) noexcept nogil
 
   void line_sender_opts_tls_insecure_skip_verify(line_sender_opts *opts) noexcept nogil

--- a/src/questdb/line_sender.pxd
+++ b/src/questdb/line_sender.pxd
@@ -103,9 +103,9 @@ cdef extern from "questdb/ingress/line_sender.h":
 
   void line_sender_opts_tls(line_sender_opts *opts) noexcept nogil
 
-  void line_sender_opts_tls_os_certs(line_sender_opts *opts) noexcept nogil
+  void line_sender_opts_tls_os_roots(line_sender_opts *opts) noexcept nogil
 
-  void line_sender_opts_tls_webpki_and_os_certs(line_sender_opts *opts) noexcept nogil
+  void line_sender_opts_tls_webpki_and_os_roots(line_sender_opts *opts) noexcept nogil
 
   void line_sender_opts_tls_ca(line_sender_opts *opts, line_sender_utf8 ca_path) noexcept nogil
 

--- a/test/test_dataframe.py
+++ b/test/test_dataframe.py
@@ -81,9 +81,8 @@ class TestPandas(unittest.TestCase):
                 'Must specify at least one of'):
             _dataframe(DF1)
 
-    # TODO: Fix me and re-enable me!
-    def _test_bad_table_name_type(self):
-        with self.assertRaisesRegex(qi.IngressError, 'Must be str'):
+    def test_bad_table_name_type(self):
+        with self.assertRaisesRegex(TypeError, "'table_name' has incorrect type"):
             _dataframe(DF1, table_name=1.5)
 
     def test_invalid_table_name(self):
@@ -808,8 +807,7 @@ class TestPandas(unittest.TestCase):
             'tbl1 a=1000000t\n' +
             'tbl1 a=2000000t\n')
 
-    # TODO: Fix me and re-enable me!
-    def _test_datetime64_tz_arrow_col(self):
+    def test_datetime64_tz_arrow_col(self):
         df = pd.DataFrame({
             'a': [
                 pd.Timestamp(
@@ -879,10 +877,10 @@ class TestPandas(unittest.TestCase):
                     year=1900, month=1, day=1,
                     hour=0, minute=0, second=0, tz=_TZ)],
             'b': ['sym1']})
-        with self.assertRaisesRegex(
-                qi.IngressError, "Failed.*'a'.*-220897.* is negative."):
-            _dataframe(df2, table_name='tbl1', symbols=['b'])
-        return   ###############################################################
+        buf = _dataframe(df2, table_name='tbl1', symbols=['b'])
+        self.assertEqual(
+            buf,
+            'tbl1,b=sym1 a=-2208970800000000t\n')
 
     def test_datetime64_numpy_at(self):
         df = pd.DataFrame({

--- a/test/test_dataframe.py
+++ b/test/test_dataframe.py
@@ -878,9 +878,13 @@ class TestPandas(unittest.TestCase):
                     hour=0, minute=0, second=0, tz=_TZ)],
             'b': ['sym1']})
         buf = _dataframe(df2, table_name='tbl1', symbols=['b'])
-        self.assertEqual(
+
+        # Accounting for different datatime library differences.
+        # Mostly, here assert that negative timestamps are allowed.
+        self.assertIn(
             buf,
-            'tbl1,b=sym1 a=-2208970800000000t\n')
+            ['tbl1,b=sym1 a=-2208970800000000t\n',
+             'tbl1,b=sym1 a=-2208971040000000t\n'])
 
     def test_datetime64_numpy_at(self):
         df = pd.DataFrame({


### PR DESCRIPTION
# More TLS connection options and new default
To connect the sender with TLS enabled one would typically use `Sender(..., tls=True)`.
This connection parameter previously used root certificates sourced from the [`webpki-roots`](https://crates.io/crates/webpki-roots) Rust crate.
With this change, `tls=True` will also use the certificates stored on the OS certificate root store.
* The `tls=True` behaviour is also equivalent to specifying `tls='webpki_and_os_roots'`.
* To use the old behaviour, use `tls='webpki_roots'`.
* Or, to only use the OS root certificate store, specify `tls='os_roots'`.