### PR TITLE
fix: auto_flush_interval no longer reduces to flushing every row

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,17 @@ Changelog
 2.0.1 (2024-03-22)
 ------------------
 
-Patch release with minor bug fixes, no API changes and some documentation tweaks.
+Patch release with bug fixes, no API changes and some documentation tweaks.
 
 Bug fixes
 ~~~~~~~~~
+* Fixed a bug where an internal "last flushed" timestamp used
+  by ``auto_flush_interval`` wasn't updated correctly causing the auto-flush
+  logic to trigger after each row.
+
 * Removed two unnecessary debugging ``print()`` statements that were
-  accidentally left in the code.
+  accidentally left in the code in ``Sender.from_conf()`` and
+  ``Sender.from_env()``.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/ci/cibuildwheel.yaml
+++ b/ci/cibuildwheel.yaml
@@ -158,7 +158,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs: {pathtoPublish: wheelhouse}
 
-      - job: windows_x64
+      - job: windows_i686
         pool: {vmImage: 'windows-2019'}
         timeoutInMinutes: 60
         steps:
@@ -170,5 +170,24 @@ stages:
             displayName: Install dependencies
           - bash: cibuildwheel --output-dir wheelhouse .
             displayName: Build wheels
+            env:
+              CIBW_BUILD: "*win32*"
+          - task: PublishBuildArtifacts@1
+            inputs: {pathtoPublish: 'wheelhouse'}
+
+      - job: windows_x86_64
+        pool: {vmImage: 'windows-2019'}
+        timeoutInMinutes: 60
+        steps:
+          - task: UsePythonVersion@0
+          - bash: |
+              set -o errexit
+              python3 -m pip install --upgrade pip
+              python3 -m pip install cibuildwheel
+            displayName: Install dependencies
+          - bash: cibuildwheel --output-dir wheelhouse .
+            displayName: Build wheels
+            env:
+              CIBW_BUILD: "*win_amd64*"
           - task: PublishBuildArtifacts@1
             inputs: {pathtoPublish: 'wheelhouse'}

--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -2432,6 +2432,8 @@ cdef class Sender:
             ok = line_sender_flush(sender, c_buf, &err)
         else:
             ok = line_sender_flush_and_keep(sender, c_buf, &err)
+        if ok and c_buf == self._buffer._impl:
+            self._last_flush_ms[0] = line_sender_now_micros() // 1000
         _ensure_has_gil(&gs)
         if not ok:
             if c_buf == self._buffer._impl:


### PR DESCRIPTION
Fixed a bug where an internal "last flushed" timestamp used by `auto_flush_interval` wasn't updated correctly causing the auto-flush logic to trigger after each row.

Closes https://github.com/questdb/py-questdb-client/issues/73