### PR TITLE
fix: fixed defaulting logic for https auto_flush_rows

### DIFF
--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -2243,6 +2243,9 @@ cdef class Sender:
     
     @property
     def auto_flush_interval(self) -> Optional[timedelta]:
+        """
+        Time interval threshold for the auto-flush logic, or None if disabled.
+        """
         if not self._auto_flush_mode.enabled:
             return None
         if self._auto_flush_mode.interval == -1:

--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -539,6 +539,12 @@ cdef bint _is_tcp_protocol(line_sender_protocol protocol):
         (protocol == line_sender_protocol_tcps))
 
 
+cdef bint _is_http_protocol(line_sender_protocol protocol):
+    return (
+        (protocol == line_sender_protocol_http) or
+        (protocol == line_sender_protocol_https))
+
+
 cdef class SenderTransaction:
     """
     A transaction for a specific table.
@@ -1428,7 +1434,7 @@ cdef uint64_t _timedelta_to_millis(object timedelta):
 
 
 cdef int64_t auto_flush_rows_default(line_sender_protocol protocol):
-    if protocol == line_sender_protocol_http:
+    if _is_http_protocol(protocol):
         return 75000
     else:
         return 600
@@ -2202,6 +2208,46 @@ cdef class Sender:
     def max_name_len(self) -> int:
         """Maximum length of a table or column name."""
         return self._max_name_len
+
+    @property
+    def auto_flush(self) -> bint:
+        """
+        Auto-flushing is enabled.
+        
+        Consult the `.auto_flush_rows`, `.auto_flush_bytes` and
+        `.auto_flush_interval` properties for the current active thresholds.
+        """
+        return self._auto_flush_mode.enabled
+
+    @property
+    def auto_flush_rows(self) -> Optional[int]:
+        """
+        Row count threshold for the auto-flush logic, or None if disabled.
+        """
+        if not self._auto_flush_mode.enabled:
+            return None
+        if self._auto_flush_mode.row_count == -1:
+            return None
+        return self._auto_flush_mode.row_count
+
+    @property
+    def auto_flush_bytes(self) -> Optional[int]:
+        """
+        Byte-count threshold for the auto-flush logic, or None if disabled.
+        """
+        if not self._auto_flush_mode.enabled:
+            return None
+        if self._auto_flush_mode.byte_count == -1:
+            return None
+        return self._auto_flush_mode.byte_count
+    
+    @property
+    def auto_flush_interval(self) -> Optional[timedelta]:
+        if not self._auto_flush_mode.enabled:
+            return None
+        if self._auto_flush_mode.interval == -1:
+            return None
+        return timedelta(milliseconds=self._auto_flush_mode.interval)
 
     def establish(self):
         """

--- a/test/test.py
+++ b/test/test.py
@@ -457,6 +457,48 @@ class TestBases:
                     # The buffer is now auto-cleared.
                     self.assertEqual(str(buf), '')
 
+        def test_auto_flush_settings_defaults(self):
+            for protocol in ('tcp', 'tcps', 'http', 'https'):
+                sender = self.builder(protocol, 'localhost', 9009)
+                self.assertTrue(sender.auto_flush)
+                self.assertEqual(sender.auto_flush_bytes, None)
+                self.assertEqual(
+                    sender.auto_flush_rows,
+                    75000 if protocol.startswith('http') else 600)
+                self.assertEqual(sender.auto_flush_interval, datetime.timedelta(seconds=1))
+
+        def test_auto_flush_settings_off(self):
+            for protocol in ('tcp', 'tcps', 'http', 'https'):
+                sender = self.builder(protocol, 'localhost', 9009, auto_flush=False)
+                self.assertFalse(sender.auto_flush)
+                self.assertEqual(sender.auto_flush_bytes, None)
+                self.assertEqual(sender.auto_flush_rows, None)
+                self.assertEqual(sender.auto_flush_interval, None)
+
+        def test_auto_flush_settings_on(self):
+            for protocol in ('tcp', 'tcps', 'http', 'https'):
+                sender = self.builder(protocol, 'localhost', 9009, auto_flush=True)
+                # Same as default.
+                self.assertEqual(sender.auto_flush_bytes, None)
+                self.assertEqual(
+                    sender.auto_flush_rows,
+                    75000 if protocol.startswith('http') else 600)
+                self.assertEqual(sender.auto_flush_interval, datetime.timedelta(seconds=1))
+
+        def test_auto_flush_settings_specified(self):
+            for protocol in ('tcp', 'tcps', 'http', 'https'):
+                sender = self.builder(
+                    protocol,
+                    'localhost',
+                    9009,
+                    auto_flush_bytes=1024,
+                    auto_flush_rows=100,
+                    auto_flush_interval=datetime.timedelta(milliseconds=50))
+                self.assertTrue(sender.auto_flush)
+                self.assertEqual(sender.auto_flush_bytes, 1024)
+                self.assertEqual(sender.auto_flush_rows, 100)
+                self.assertEqual(sender.auto_flush_interval, datetime.timedelta(milliseconds=50))
+
         def test_auto_flush(self):
             with Server() as server:
                 with self.builder(


### PR DESCRIPTION
The default for `auto_flush_rows` was incorrectly set to 600 (instead of 75000) when connecing over HTTPS (and not HTTP which was correct).

This caused performance issues since small requests in HTTP are not very efficient.

This PR fixes the default and restores good performance using default settings when using HTTPs and auto-flushing.

A workaround in v2.0.1 before this PR is to set the `auto_flush_rows` setting to 75000 explicitly in the config string.