### PR TITLE
Remove redundant 3.13 version check for fastparquet from build

### DIFF
--- a/ci/pip_install_deps.py
+++ b/ci/pip_install_deps.py
@@ -93,8 +93,7 @@ def main(args):
         import pandas
         import numpy
         import pyarrow
-        if (sys.version_info >= (3, 8) and sys.version_info < (3, 13)):
-            # As of this commit, fastparquet does not have a binary built for 3.13
+        if sys.version_info >= (3, 8):
             import fastparquet
 
 


### PR DESCRIPTION
Low impact, low priority, fastparquet now was 3.13 builds, removing this redundant check from my last commit.