### PR TITLE
fix error message typo

### DIFF
--- a/src/questdb/ingress.pyx
+++ b/src/questdb/ingress.pyx
@@ -1032,7 +1032,7 @@ cdef class Buffer:
                 'float',
                 'str',
                 'TimestampMicros',
-                'datetime.datetime'
+                'datetime.datetime',
                 'numpy.ndarray'))
             raise TypeError(
                 f'Unsupported type: {_fqn(type(value))}. Must be one of: {valid}')


### PR DESCRIPTION
I encountered an error message:

```
TypeError: Unsupported type: list. Must be one of: bool, int, float, str, TimestampMicros, datetime.datetimenumpy.ndarray
```

The last two entries are smushed together, probably because of the missing comma.


@kafka1991 Please check it out when you get the chance!