### PR TITLE
Fix flaky test_http_request_timeout on CI

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -1125,9 +1125,10 @@ class TestBases:
                     retry_timeout=0,
                     request_min_throughput=0,  # disable
                     protocol_version=2,
-                    request_timeout=datetime.timedelta(milliseconds=5)) as sender:
-                # wait for 50ms in the server to simulate a slow response
-                server.responses.append((50, 200, 'text/plain', b'OK'))
+                    request_timeout=datetime.timedelta(milliseconds=50)) as sender:
+                # Server waits 500ms before responding; the client should
+                # time out at 50ms, well before the response arrives.
+                server.responses.append((500, 200, 'text/plain', b'OK'))
                 sender.row('tbl1', columns={'x': 42}, at=qi.ServerTimestamp)
                 with self.assertRaisesRegex(qi.IngressError, 'timeout: per call'):
                     sender.flush()


### PR DESCRIPTION
## Summary
- `test_http_request_timeout` used a 5ms client timeout with a 50ms server delay — too tight for loaded CI runners where the HTTP roundtrip over localhost could complete before the timeout check fired
- Widened to 50ms timeout / 500ms server delay (10x ratio) to reliably trigger the timeout while keeping shutdown cost under 500ms

## Test plan
- [ ] CI passes without the flaky `test_http_request_timeout` failure on macOS x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated HTTP request timeout test parameters to improve timeout behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->