### PR TITLE
ci: migrate ARM64 wheel builds from AWS Lambda to Hetzner Incus

### DIFF
--- a/ci/cibuildwheel.yaml
+++ b/ci/cibuildwheel.yaml
@@ -20,7 +20,7 @@ stages:
               python3 -m pip install --upgrade pip --break-system-packages
               python3 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 -m cibuildwheel --output-dir wheelhouse .
             displayName: Build wheels
           - task: PublishBuildArtifacts@1
             inputs: {pathtoPublish: 'wheelhouse'}

--- a/ci/cibuildwheel.yaml
+++ b/ci/cibuildwheel.yaml
@@ -13,11 +13,12 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: true
-          # - task: UsePythonVersion@0
           - bash: |
               set -o errexit
-              python3 -m pip install --upgrade pip
-              python3 -m pip install cibuildwheel
+              sudo apt-get update
+              sudo apt-get install -y python3-pip python3-venv
+              python3 -m pip install --upgrade pip --break-system-packages
+              python3 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
           - bash: cibuildwheel --output-dir wheelhouse .
             displayName: Build wheels

--- a/ci/cibuildwheel.yaml
+++ b/ci/cibuildwheel.yaml
@@ -4,58 +4,8 @@ stages:
   - stage: cibuildwheel
     condition: eq(variables['System.PullRequest.IsFork'], 'false')
     jobs:
-      - job: start_linux_arm64_agent_aws
-        pool:
-          vmImage: "ubuntu-latest"
-        steps:
-          - checkout: none
-          - bash: |
-              echo "buildno: $(Build.BuildId)"
-              echo ${AZURE_DEVOPS_CLI_PAT} | az devops login
-            env:
-              AZURE_DEVOPS_CLI_PAT: $(System.AccessToken)
-            displayName: "Login Azure DevOps Extension"
-          - bash:
-              az devops configure --defaults
-              organization=$(System.TeamFoundationCollectionUri)
-              project=$(System.TeamProject) --use-git-aliases true
-            displayName: "Set default Azure DevOps organization and project"
-          - task: LambdaInvokeFunction@1
-            displayName: "Start Agent 1"
-            name: "Start_Agent1"
-            inputs:
-              awsCredentials: "ondemand-dev"
-              regionName: "eu-west-1"
-              functionName: "ondemand-pipeline"
-              payload: |
-                {
-                  "pool": "arm64-clients",
-                  "buildid": "$(Build.BuildId)"
-                }
-              outputVariable: "functionResult"
-          - bash: |
-              echo "Instance: $(functionResult)"
-            name: "Display_Instance"
-            displayName: "Display Instance"
-          - bash: |
-              echo "Starting agent... for pool arm64-clients"
-              POOLID=$(az pipelines pool list | jq '.[]| select(.name == "arm64-clients") | .id' -r)
-              while [ "$(az pipelines agent list --pool-id $POOLID | jq '.[]| select(.name == "arm64-clients-$(Build.BuildId)") | .enabled' -r)" != "true" ]
-              do
-                echo "Still waiting for agent arm64-clients-$(Build.BuildId) ... "
-                sleep 3
-              done
-              echo "Agent found ..."
-            name: "Check_agent"
-            displayName: "Check agent"
-            timeoutInMinutes: 20
       - job: linux_arm64
-        pool:
-          name: "arm64-clients"
-          demands:
-            - Agent.Name -equals arm64-clients-$(Build.BuildId)
-        dependsOn:
-          - start_linux_arm64_agent_aws
+        pool: hetzner-incus-arm
         timeoutInMinutes: 90
         condition: eq(variables['System.PullRequest.IsFork'], 'false')
         steps:


### PR DESCRIPTION
## Summary
- Replace the on-demand AWS Lambda runner provisioning (`arm64-clients` pool) with the shared `hetzner-incus-arm` pool already used by `questdb` and `questdb-enterprise`
- Remove the `start_linux_arm64_agent_aws` job (Lambda invocation, Azure DevOps CLI login, agent polling loop)
- Net removal of 50 lines of CI plumbing

## Test plan
- Trigger a cibuildwheel pipeline run and verify the `linux_arm64` job picks up a Hetzner ARM agent
- Verify ARM64 wheels build and publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ARM64 builds now run on a fixed hosted agent pool instead of per-build provisioned agents.
  * Dependency installation for ARM64 builds adjusted to install system Python packages and allow pip installs that override system restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->