### PR TITLE
fix: support latest QWP client contracts

### DIFF
--- a/.github/workflows/macos-arm64-wheels.yml
+++ b/.github/workflows/macos-arm64-wheels.yml
@@ -28,6 +28,12 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: arm64
           MACOSX_DEPLOYMENT_TARGET: "11.0"
+          # List versions explicitly, as the Azure jobs do. cibuildwheel
+          # builds a new CPython as soon as it reaches its first release
+          # candidate, so a wildcard here pulls in pre-release Pythons on a
+          # cibuildwheel upgrade. Add a version here once it is GA and its
+          # dependencies publish wheels.
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-macos-arm64

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,32 @@
 Changelog
 =========
 
+5.0.1 (unreleased)
+------------------
+
+- Applications may now create a ``QueryResult`` on one thread and process it on
+  another, including through its Arrow stream. Hand it off with normal thread
+  synchronization and never use it from two threads at once. If it came from a
+  ``PooledReader``, keep that reader on its original thread until processing
+  finishes.
+- WebSocket connections keep a dictionary of ``SYMBOL`` values to avoid sending
+  repeated text in full. Repeated values do not grow it, but a long-lived
+  connection fills it after 2,000,000 distinct values or 256 MiB of symbol
+  text. The client then raises
+  ``QuestDBErrorCode.SymbolDictFull``. Pooled clients replace the connection;
+  standalone senders should call ``close_drain()`` and reconnect. Before
+  retrying, check ``err.in_doubt``; when it is true, some rows may already be
+  stored.
+- If a DataFrame load fails, batches waiting in memory are now discarded. Most
+  loads commit once at the end, but very large Arrow loads may commit an earlier
+  checkpoint. If a later batch fails, that prefix from the same DataFrame call
+  remains, so retrying the whole DataFrame can duplicate rows.
+- When ``sf_dir`` enables disk-backed delivery, shutdown now obeys its configured
+  timeout and recovery is safer after a crash or an incomplete final write.
+- If a ``ws::`` or ``wss::`` configuration contains ``max_in_flight`` or
+  ``in_flight_window``, remove it. These options are no longer supported and now
+  raise ``QuestDBErrorCode.ConfigError`` during startup.
+
 5.0.0 (2026-07-27)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changelog
   repeated text in full. Repeated values do not grow it, but a long-lived
   connection fills it after 2,000,000 distinct values or 256 MiB of symbol
   text. The client then raises
+  :class:`QuestDBError <questdb.QuestDBError>` with ``code`` set to
   ``QuestDBErrorCode.SymbolDictFull``. Pooled clients replace the connection;
   standalone senders should call ``close_drain()`` and reconnect. Before
   retrying, check ``err.in_doubt``; when it is true, some rows may already be
@@ -28,7 +29,8 @@ Changelog
   timeout and recovery is safer after a crash or an incomplete final write.
 - If a ``ws::`` or ``wss::`` configuration contains ``max_in_flight`` or
   ``in_flight_window``, remove it. These options are no longer supported and now
-  raise ``QuestDBErrorCode.ConfigError`` during startup.
+  raise :class:`QuestDBError <questdb.QuestDBError>` with ``code`` set to
+  ``QuestDBErrorCode.ConfigError`` during startup.
 
 5.0.0 (2026-07-27)
 ------------------

--- a/ci/cibuildwheel.yaml
+++ b/ci/cibuildwheel.yaml
@@ -204,6 +204,11 @@ stages:
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp310-* cp311-*"
+              # Log the resolved test environment and emit all Python thread
+              # stacks if the test suite stops making progress.
+              CIBW_TEST_COMMAND: >-
+                python {project}/ci/run_tests_with_watchdog.py
+                {project}/test/test.py -v
           - task: PublishBuildArtifacts@1
             inputs: {pathtoPublish: wheelhouse}
 

--- a/ci/cibuildwheel.yaml
+++ b/ci/cibuildwheel.yaml
@@ -284,7 +284,10 @@ stages:
             displayName: Build wheels
             env:
               CIBW_ENVIRONMENT: "MSSdk=1 DISTUTILS_USE_SDK=1 SETUP_DO_GIT_SUBMODULE_INIT=1"
-              CIBW_BUILD: "*win32*"
+              # List versions explicitly, as the other jobs do. A `*win32*`
+              # wildcard also matches pre-release Pythons, which cibuildwheel
+              # starts building at the first release candidate.
+              CIBW_BUILD: "cp310-win32 cp311-win32 cp312-win32 cp313-win32 cp314-win32"
           - task: PublishBuildArtifacts@1
             inputs: {pathtoPublish: 'wheelhouse'}
 
@@ -313,7 +316,12 @@ stages:
               cibuildwheel --output-dir wheelhouse .
             displayName: Build wheels
             env:
-              CIBW_BUILD: "*win_amd64*"
+              # List versions explicitly, as the other jobs do. A `*win_amd64*`
+              # wildcard also matches pre-release Pythons, which cibuildwheel
+              # starts building at the first release candidate.
+              # `cp314t-win_amd64` is left out: it was blocked by missing
+              # pandas wheels, which now exist, so it can be added and tested.
+              CIBW_BUILD: "cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp314-win_amd64"
               CIBW_ENVIRONMENT: "MSSdk=1 DISTUTILS_USE_SDK=1 SETUP_DO_GIT_SUBMODULE_INIT=1"
               CIBW_BUILD_VERBOSITY: "3"
               DISTUTILS_DEBUG: "1"

--- a/ci/run_tests_with_watchdog.py
+++ b/ci/run_tests_with_watchdog.py
@@ -1,0 +1,121 @@
+"""Run a Python test script with CI hang diagnostics enabled."""
+
+import faulthandler
+import functools
+import os
+import platform
+from pathlib import Path
+import runpy
+import subprocess
+import sys
+import unittest
+
+
+DEFAULT_WATCHDOG_SECONDS = 15 * 60
+WATCHDOG_SECONDS_ENV = 'QDB_TEST_WATCHDOG_SECONDS'
+
+
+def watchdog_seconds():
+    value = os.environ.get(
+        WATCHDOG_SECONDS_ENV,
+        str(DEFAULT_WATCHDOG_SECONDS))
+    try:
+        seconds = int(value)
+    except ValueError:
+        raise SystemExit(
+            f'{WATCHDOG_SECONDS_ENV} must be a positive integer, got {value!r}')
+    if seconds <= 0:
+        raise SystemExit(
+            f'{WATCHDOG_SECONDS_ENV} must be a positive integer, got {value!r}')
+    return seconds
+
+
+def print_environment():
+    print('=== test environment ===', file=sys.stderr, flush=True)
+    print(f'executable: {sys.executable}', file=sys.stderr, flush=True)
+    print(f'python: {sys.version}', file=sys.stderr, flush=True)
+    print(f'platform: {platform.platform()}', file=sys.stderr, flush=True)
+    print('packages (pip freeze --all):', file=sys.stderr, flush=True)
+    try:
+        result = subprocess.run(
+            [sys.executable, '-m', 'pip', 'freeze', '--all'],
+            stdout=sys.stderr,
+            stderr=sys.stderr,
+            check=False)
+    except OSError as error:
+        print(
+            f'warning: unable to run pip freeze: {error}',
+            file=sys.stderr,
+            flush=True)
+    else:
+        if result.returncode != 0:
+            print(
+                f'warning: pip freeze exited with status {result.returncode}',
+                file=sys.stderr,
+                flush=True)
+    print('=== end test environment ===', file=sys.stderr, flush=True)
+
+
+def arm_watchdog(seconds):
+    faulthandler.cancel_dump_traceback_later()
+    faulthandler.dump_traceback_later(
+        seconds,
+        repeat=False,
+        exit=True)
+
+
+def install_unittest_watchdog(seconds):
+    original_start_test = unittest.TestResult.startTest
+
+    @functools.wraps(original_start_test)
+    def start_test(result, test):
+        arm_watchdog(seconds)
+        return original_start_test(result, test)
+
+    unittest.TestResult.startTest = start_test
+    return original_start_test
+
+
+def run_test_script(test_script, test_args):
+    original_argv = sys.argv
+    original_path = sys.path[:]
+    sys.argv = [str(test_script), *test_args]
+    sys.path.insert(0, str(test_script.parent))
+    try:
+        runpy.run_path(str(test_script), run_name='__main__')
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_path
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(
+            f'usage: {Path(sys.argv[0]).name} TEST_SCRIPT [TEST_ARG ...]',
+            file=sys.stderr)
+        return 2
+
+    test_script = Path(sys.argv[1]).resolve()
+    if not test_script.is_file():
+        print(f'test script does not exist: {test_script}', file=sys.stderr)
+        return 2
+
+    seconds = watchdog_seconds()
+    print_environment()
+    faulthandler.enable(all_threads=True)
+    original_start_test = install_unittest_watchdog(seconds)
+    print(
+        f'Test watchdog armed for {seconds} seconds without test progress.',
+        file=sys.stderr,
+        flush=True)
+    arm_watchdog(seconds)
+    try:
+        run_test_script(test_script, sys.argv[2:])
+    finally:
+        faulthandler.cancel_dump_traceback_later()
+        unittest.TestResult.startTest = original_start_test
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -309,9 +309,6 @@ Advanced QWP tuning
 
 Rarely needed; the defaults suit most deployments.
 
-* ``max_in_flight`` - ``int``: Published-but-unacknowledged frame window
-  per connection. Default: 128.
-
 * ``max_frame_rejections`` - ``int``: Consecutive no-progress rejections of
   the same frame before the client stops retrying it and turns terminal.
   Default: 4.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -89,17 +89,24 @@ handle; the sender variants exist as conveniences and share the same path:
     with Sender.from_conf('ws::addr=localhost:9000;') as sender:
         sender.dataframe(frame, table_name='weather', at='ts')
 
-All commit the whole source before returning, are independent of ``sf_dir``,
-and re-send from your DataFrame on transient failures (raising with
-``in_doubt`` set when a blind re-send could duplicate rows); none converts
-the dataframe into row calls. ``dataframe()`` opens a direct connection just
-for that call (borrowed from the pool for a pooled sender, opened from the
-sender's own configuration — carrying its auth/TLS — for a standalone one)
-and commits immediately — it has **no ordering relationship** with rows
-buffered on a sender via ``row()`` and does not flush them; publish those
-with ``flush()``. This works for any standalone ws sender, whether built
-via ``Sender.from_conf`` / ``Sender.from_env`` or the ``Sender(...)``
-constructor.
+On success, each call returns only after every row in the source has been
+committed. Most loads queue their batches and commit once at the end. To keep
+memory bounded, a very large Arrow load checkpoints about every 100 batches.
+The client may checkpoint earlier if the connection cannot queue another batch
+or if a batch must be split to fit. If a later batch fails, the exception means
+that the load did not finish, not necessarily that no rows landed. Any already
+committed prefix from that call remains in the table, and retrying the entire
+DataFrame can duplicate it unless the table uses suitable
+``DEDUP UPSERT KEYS``.
+
+These calls are independent of ``sf_dir``, and none converts the DataFrame
+into row calls. ``dataframe()`` opens a direct connection just for that call
+(borrowed from the pool for a pooled sender, opened from the sender's own
+configuration — carrying its auth/TLS — for a standalone one). It has **no
+ordering relationship** with rows buffered on a sender via ``row()`` and does
+not flush them; publish those with ``flush()``. This works for any standalone
+ws sender, whether built via ``Sender.from_conf`` / ``Sender.from_env`` or the
+``Sender(...)`` constructor.
 
 Over ILP/HTTP, ILP/TCP and QWP/UDP, ``sender.dataframe()`` is unchanged and
 fully supported (over UDP it serializes row by row into fire-and-forget
@@ -128,6 +135,11 @@ through one sender, borrow one pooled sender per thread instead.
 
 Behavioural changes to watch for
 ================================
+
+* **Removed QWP flight-window keys.** ``max_in_flight`` and
+  ``in_flight_window`` are no longer accepted. Remove them from ws/wss
+  configuration strings; the client raises ``QuestDBError(ConfigError)``
+  instead of silently ignoring an obsolete setting.
 
 * **Broader** ``except IngressError``. ``IngressError`` is an alias of the
   unified :class:`QuestDBError <questdb.QuestDBError>`, so handlers written

--- a/docs/sender.rst
+++ b/docs/sender.rst
@@ -994,6 +994,16 @@ it durably applies them, so the client can confirm delivery.
   diagnostics through the ``error_handler`` passed to
   :func:`questdb.connect`, on a dedicated dispatcher thread.
 
+* **Full symbol dictionary.** ``QuestDBErrorCode.SymbolDictFull`` means that
+  a ws/wss connection has exhausted its connection-scoped symbol dictionary.
+  Retrying a new symbol on that sender cannot succeed. Return a pooled sender
+  normally so the connection is retired, then borrow a fresh sender. If older
+  published frames must be confirmed first, wait for their FSN before returning
+  the sender. For a standalone sender, call ``close_drain()`` and check that it
+  succeeds, then close and reopen it. Check ``err.in_doubt`` before replaying
+  the failed input: a chunked flush may already have published an earlier
+  prefix.
+
 * **Draining on close.** :func:`Sender.close_drain <questdb.Sender.close_drain>` waits for outstanding
   frames to be acknowledged before closing.
 
@@ -1137,6 +1147,10 @@ while preserving the connection, call
 draining to a terminal reply, then close the result (or leave its context
 manager).
 
+A result, including its Arrow C stream, may be handed to a worker thread.
+Use a synchronized hand-off and access it from only one thread at a time;
+concurrent consumption, cancellation, and close are unsupported.
+
 ``SYMBOL`` columns: ``to_polars`` / ``to_pandas`` build the categorical directly
 (connection dictionary interned once, no per-row remap). ``to_arrow`` /
 ``iter_arrow`` / ``__arrow_c_stream__`` emit a generic Arrow form whose
@@ -1170,16 +1184,25 @@ a fresh one. To abandon a result without losing the lease, call ``cancel()``
 and then ``close()``; cancellation drains to terminal, so the next query can
 reuse the connection. A lease has thread affinity: use one lease per thread,
 on the thread that created it (threads sharing a
-:class:`QuestDB <questdb.QuestDB>` handle each take their own lease).
+:class:`QuestDB <questdb.QuestDB>` handle each take their own lease). A
+:class:`QueryResult <questdb.QueryResult>` may be handed to a worker thread;
+join that worker before using the lease for its next query.
 
-The same :class:`QuestDB <questdb.QuestDB>` can ingest dataframes through the pooled columnar QWP
-path with :meth:`QuestDB.dataframe <questdb.QuestDB.dataframe>`. Dataframe ingestion always uses the direct
-(non-store-and-forward) column sender, independent of ``sf_dir``, and returns
-once the whole frame is committed (``AckLevel::Ok``). On a transient connection
-failure the frame is re-sent from the caller's DataFrame only when the failed
-operation is provably not delivered. If the native client reports delivery as
-in doubt, or an intermediate commit checkpoint on a large frame has already
-landed, the error surfaces immediately and a committed prefix may remain in the
-table. Retrying an in-doubt operation can duplicate rows unless the table has
-appropriate ``DEDUP UPSERT KEYS``.
+The same :class:`QuestDB <questdb.QuestDB>` can ingest DataFrames through the pooled columnar QWP
+path with :meth:`QuestDB.dataframe <questdb.QuestDB.dataframe>`. DataFrame ingestion always uses the direct
+(non-store-and-forward) column sender, independent of ``sf_dir``.
+
+On success, the call returns only after every row has been committed. Most
+loads queue their batches and commit once at the end. A very large Arrow load
+checkpoints about every 100 batches to keep memory bounded. The client may
+checkpoint earlier if the connection cannot queue another batch or if a batch
+must be split to fit. If a later batch fails, the exception means that the load
+did not finish, not necessarily that no rows landed. Any already committed
+prefix from that call remains in the table, and retrying the entire DataFrame
+can duplicate it unless the table uses suitable ``DEDUP UPSERT KEYS``.
+
+On a transient connection failure, the client re-sends from the caller's
+DataFrame only when it knows that no rows landed. Otherwise it reports the
+error instead of risking a blind retry.
+
 * Any :ref:`authentication parameters <sender_conf_auth>` such as ``username``, ``token``, et cetera.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,9 @@ skip = [
     # Those builds are named `*win32*` in cibuildwheel.
     "*i686*",
 
-    # Temporarily skip the 3.14 free-threaded built on Windows.
-    # Pandas dependencies missing.
-    "*314t-win*"
+    # Note: each job selects its Python versions through `CIBW_BUILD`. That
+    # list is the single gate on which versions we build. Do not add a
+    # version filter here as well, or the two will disagree.
 ]
 
 # [tool.cibuildwheel.windows]

--- a/src/questdb/_client.pyi
+++ b/src/questdb/_client.pyi
@@ -1247,12 +1247,14 @@ class QuestDB:
         safety limit: any batch exceeding the negotiated per-batch byte
         cap is split regardless of it, and a single row is never bounded
         by it. Each batch is one unit of client memory and server-side
-        apply, and a commit checkpoint fires every ~100 batches, so
-        ``max_rows_per_batch * 100`` rows is the replay window on a
-        transient failover. Raise it for narrow numeric rows; lower it
-        for very wide rows or tight memory. Streaming Arrow input
-        (``pa.RecordBatchReader``) is not re-batched — the producer's
-        batch size governs.
+        apply. Sliceable Arrow inputs checkpoint about every 100 batches,
+        so ``max_rows_per_batch * 100`` rows approximates their periodic
+        replay window. The NumPy planner normally commits once after the
+        whole frame. Either path may checkpoint earlier when deferred
+        capacity fills. Raise ``max_rows_per_batch`` for narrow numeric
+        rows; lower it for very wide rows or tight memory. Streaming Arrow
+        input (``pa.RecordBatchReader``) is not re-batched — the producer's
+        batch size governs its checkpoint window.
         """
 
     def query(

--- a/src/questdb/_client.pyi
+++ b/src/questdb/_client.pyi
@@ -99,6 +99,7 @@ class QuestDBErrorCode(Enum):
     ArrowExport = ...
     BatchTooLarge = ...
     StoreResendRequired = ...
+    SymbolDictFull = ...
     BadDataFrame = ...
 
 
@@ -1200,6 +1201,18 @@ class QuestDB:
     ) -> QuestDB:
         """
         Ingest a dataframe through the pooled columnar QWP path.
+
+        Ingestion always uses the direct (non-store-and-forward) column
+        sender, independent of ``sf_dir``. On success, the call returns only
+        after every DataFrame batch has been committed. Most loads queue their
+        batches and commit once at the end. Large Arrow inputs checkpoint about
+        every 100 batches to keep memory bounded. The client may checkpoint
+        earlier if the connection cannot queue another batch or if a batch must
+        be split to fit. If a later batch fails, the exception means that the
+        load did not finish, not necessarily that no rows landed. Any already
+        committed prefix from this call remains, and retrying the whole
+        DataFrame can duplicate it unless the destination table uses suitable
+        ``DEDUP UPSERT KEYS``.
 
         ``at`` names the designated timestamp column (by name or index),
         or a fixed ``TimestampNanos`` / ``datetime`` shared by every row,

--- a/src/questdb/_client.pyx
+++ b/src/questdb/_client.pyx
@@ -6428,12 +6428,14 @@ cdef class QuestDB:
         safety limit: any batch exceeding the negotiated per-batch byte
         cap is split regardless of it, and a single row is never bounded
         by it. Each batch is one unit of client memory and server-side
-        apply, and a commit checkpoint fires every ~100 batches, so
-        ``max_rows_per_batch * 100`` rows is the replay window on a
-        transient failover. Raise it for narrow numeric rows; lower it
-        for very wide rows or tight memory. Streaming Arrow input
-        (``pa.RecordBatchReader``) is not re-batched — the producer's
-        batch size governs.
+        apply. Sliceable Arrow inputs checkpoint about every 100 batches,
+        so ``max_rows_per_batch * 100`` rows approximates their periodic
+        replay window. The NumPy planner normally commits once after the
+        whole frame. Either path may checkpoint earlier when deferred
+        capacity fills. Raise ``max_rows_per_batch`` for narrow numeric
+        rows; lower it for very wide rows or tight memory. Streaming Arrow
+        input (``pa.RecordBatchReader``) is not re-batched — the producer's
+        batch size governs its checkpoint window.
         """
         cdef qdb_pystr_buf* b = qdb_pystr_buf_new()
         cdef dataframe_plan_t plan = dataframe_plan_blank()

--- a/src/questdb/_client.pyx
+++ b/src/questdb/_client.pyx
@@ -202,6 +202,7 @@ class QuestDBErrorCode(Enum):
     ArrowExport = line_sender_error_arrow_export
     BatchTooLarge = line_sender_error_batch_too_large
     StoreResendRequired = line_sender_error_store_resend_required
+    SymbolDictFull = line_sender_error_symbol_dict_full
     # Python-only sentinel with no backing FFI code: raised by the Cython
     # DataFrame-shape validation path. Sits in a reserved high band, disjoint
     # from the contiguous FFI code space, so an appended FFI variant can never
@@ -384,8 +385,15 @@ cdef inline object c_err_code_to_py(line_sender_error_code code):
         return QuestDBErrorCode.BatchTooLarge
     elif code == line_sender_error_store_resend_required:
         return QuestDBErrorCode.StoreResendRequired
+    elif code == line_sender_error_symbol_dict_full:
+        return QuestDBErrorCode.SymbolDictFull
     else:
         raise ValueError('Internal error converting error code.')
+
+
+def _debug_error_code_to_py(int raw_code):
+    """Internal ABI test hook for the native-to-Python error mapping."""
+    return c_err_code_to_py(<line_sender_error_code>raw_code)
 
 
 cdef inline object c_sender_error_view_to_raw(
@@ -6306,18 +6314,21 @@ cdef class QuestDB:
         Ingest a dataframe through the pooled columnar QWP path.
 
         Ingestion always uses the direct (non-store-and-forward) column
-        sender, independent of ``sf_dir``, and returns once the whole frame
-        is committed (``AckLevel::Ok``). On a transient connection failure
-        the frame is re-sent from the caller's DataFrame within the pool's
-        reconnect budget — unless the native client reports delivery as in
-        doubt, or an intermediate commit checkpoint (emitted every ~100 batches
-        on large frames) has already landed. In either case the error is raised
-        immediately and a committed prefix may remain in the table, since a
-        blind re-send would duplicate it. Delivery is
-        at-least-once: a re-sent frame can duplicate already-committed rows
-        (including the first chunk, which commits eagerly on a fresh
-        connection) unless the table has ``DEDUP UPSERT KEYS``. Server-side
-        rejections (e.g. a schema mismatch) surface as a plain
+        sender, independent of ``sf_dir``. On success, the call returns only
+        after every DataFrame batch has been committed. Most loads queue their
+        batches and commit once at the end. Large Arrow inputs checkpoint about
+        every 100 batches to keep memory bounded. The client may checkpoint
+        earlier if the connection cannot queue another batch or if a batch must
+        be split to fit. If a later batch fails, the exception means that the
+        load did not finish, not necessarily that no rows landed. Any already
+        committed prefix from this call remains, and retrying the whole
+        DataFrame can duplicate it unless the destination table uses suitable
+        ``DEDUP UPSERT KEYS``.
+
+        On a transient connection failure, the client re-sends from the
+        original DataFrame only when it knows that no rows landed. Otherwise it
+        raises instead of risking a blind retry. Server-side rejections (e.g. a
+        schema mismatch) surface as a plain
         :class:`QuestDBError`; the structured ``sender_error`` diagnostic
         is attached only by the store-and-forward senders.
 
@@ -8896,7 +8907,10 @@ cdef class PooledReader:
 
     The lease counts as an active use of the :class:`QuestDB` handle
     (``QuestDB.close()`` waits for it) and has thread affinity: use one
-    lease per thread, on the thread that created it.
+    lease per thread, on the thread that created it. A
+    :class:`QueryResult` returned by the lease may be handed to a worker
+    under that result's thread hand-off rules; wait for it to finish
+    before using the lease again.
     """
     cdef QuestDB _handle
     cdef _ReaderHandle _reader
@@ -8969,7 +8983,7 @@ cdef class PooledReader:
             self._check_open('query')
             last = self._last_cursor
             if last is not None:
-                if last._cursor != NULL:
+                if last._is_live():
                     raise QuestDBError(
                         QuestDBErrorCode.InvalidApiCall,
                         'the previous QueryResult is still open: drain '
@@ -8984,8 +8998,7 @@ cdef class PooledReader:
                         'this lease and obtain a new one with '
                         'QuestDB.reader().')
             cursor_handle = _execute_query(
-                self._reader, sql, binds, reset_symbol_dict)
-            cursor_handle._owns_reader = False
+                self._reader, sql, binds, reset_symbol_dict, False)
             self._last_cursor = cursor_handle
         return QueryResult(cursor_handle)
 

--- a/src/questdb/_client.pyx
+++ b/src/questdb/_client.pyx
@@ -72,7 +72,8 @@ from cpython.datetime cimport (
     PyDateTime_DATE_GET_SECOND, PyDateTime_DATE_GET_MICROSECOND,
 )
 from cpython.bool cimport bool
-from cpython.weakref cimport PyWeakref_NewRef, PyWeakref_GetObject
+from cpython.ref cimport Py_XDECREF
+from cpython.weakref cimport PyWeakref_NewRef, PyWeakref_GetRef
 from cpython.object cimport PyObject
 from cpython.buffer cimport Py_buffer, PyObject_CheckBuffer, \
     PyObject_GetBuffer, PyBuffer_Release, PyBUF_SIMPLE
@@ -1335,12 +1336,14 @@ cdef class Buffer:
                 f'Unsupported type: {_fqn(type(value))}. Must be one of: {valid}')
 
     cdef inline void_int _may_trigger_row_complete(self) except -1:
-        cdef line_sender_error* err = NULL
         cdef PyObject* sender = NULL
         if self._row_complete_sender != None:
-            sender = PyWeakref_GetObject(self._row_complete_sender)
-            if sender != NULL and <object>sender is not None:
-                may_flush_on_row_complete(self, <Sender><object>sender)
+            if PyWeakref_GetRef(self._row_complete_sender, &sender):
+                try:
+                    may_flush_on_row_complete(
+                        self, <Sender><object>sender)
+                finally:
+                    Py_XDECREF(sender)
 
     cdef inline void_int _at_ts_us(self, TimestampMicros ts) except -1:
         cdef line_sender_error* err = NULL

--- a/src/questdb/egress.pxi
+++ b/src/questdb/egress.pxi
@@ -128,15 +128,16 @@ cdef class _CursorHandle:
         self._lock = threading.RLock()
         self._reset_seq = 0
 
-    cdef _attach(
+    cdef void _attach(
             self,
             qwp_reader_cursor* cursor,
             _ReaderHandle reader_ref,
-            bint owns_reader):
-        with self._lock:
-            self._cursor = cursor
-            self._reader_ref = reader_ref
-            self._owns_reader = owns_reader
+            bint owns_reader) noexcept:
+        # The handle is new and has not been published yet, so adopting the
+        # cursor needs no lock and must not introduce a failure point.
+        self._cursor = cursor
+        self._reader_ref = reader_ref
+        self._owns_reader = owns_reader
 
     cdef bint _is_live(self):
         with self._lock:

--- a/src/questdb/egress.pxi
+++ b/src/questdb/egress.pxi
@@ -85,10 +85,16 @@ cdef class _ReaderHandle:
 cdef class _CursorHandle:
     """Owns a ``qwp_reader_cursor*`` + back-ref to its reader.
 
-    ``_free()`` releases both: the cursor is freed and the reader
-    closed (returned to its pool or dropped) in the same locked
-    section. The drain / close / consumer-teardown paths call it
-    eagerly; ``__dealloc__`` is the backstop.
+    The re-entrant lock is the publication boundary for every native
+    cursor field. It serialises cursor operations, close, Arrow consumer
+    callbacks, and GC finalisation, and supplies the happens-before edge
+    required when those operations move between threads. Concurrent
+    public operations are still unsupported.
+
+    ``_free()`` releases both: the cursor is freed and the reader closed
+    (returned to its pool or dropped) in the same locked section. The
+    drain / close / consumer-teardown paths call it eagerly;
+    ``__dealloc__`` is the backstop.
 
     ``_owns_reader`` selects who releases the reader. The one-shot
     ``QuestDB.query(sql)`` path leaves it ``True``: the cursor is the
@@ -119,12 +125,34 @@ cdef class _CursorHandle:
         self._cursor = NULL
         self._reader_ref = None
         self._owns_reader = True
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._reset_seq = 0
 
-    cdef _attach(self, qwp_reader_cursor* cursor, _ReaderHandle reader_ref):
-        self._cursor = cursor
-        self._reader_ref = reader_ref
+    cdef _attach(
+            self,
+            qwp_reader_cursor* cursor,
+            _ReaderHandle reader_ref,
+            bint owns_reader):
+        with self._lock:
+            self._cursor = cursor
+            self._reader_ref = reader_ref
+            self._owns_reader = owns_reader
+
+    cdef bint _is_live(self):
+        with self._lock:
+            return self._cursor != NULL
+
+    cdef int _reset_sequence(self):
+        with self._lock:
+            return self._reset_seq
+
+    cdef bint _abandonment_needs_warning(self):
+        with self._lock:
+            return (
+                self._cursor != NULL
+                and (
+                    self._reader_ref is None
+                    or self._reader_ref._must_close))
 
     cdef void _free(self) noexcept:
         cdef PyThreadState* gs = NULL
@@ -211,17 +239,19 @@ cdef tuple _fetch_all_record_batches(
     the cursor is freed and the reader marked drained on clean
     end-of-stream.
     """
-    cdef int seen_seq = handle._reset_seq
+    cdef int seen_seq = handle._reset_sequence()
+    cdef int current_seq
     cdef object schema = None
     cdef list batches = []
     cdef object batch
     try:
         while True:
             batch = _fetch_one_batch(handle, pa_module, compact)
-            if handle._reset_seq != seen_seq:
+            current_seq = handle._reset_sequence()
+            if current_seq != seen_seq:
                 # Mid-query failover replayed from batch-0: drop the
                 # pre-failover accumulation and re-pin the schema.
-                seen_seq = handle._reset_seq
+                seen_seq = current_seq
                 batches = []
                 schema = None
             if batch is None:
@@ -262,7 +292,7 @@ cdef object _build_record_batch_reader(
     # Pin the sequence after the first batch: a pre-delivery failover
     # replays batch-0 transparently into ``first``, so only resets that
     # happen once batches are flowing can duplicate already-yielded data.
-    cdef int seen_seq = cursor_handle._reset_seq
+    cdef int seen_seq = cursor_handle._reset_sequence()
     schema = first.schema
 
     def _gen(compact):
@@ -270,7 +300,7 @@ cdef object _build_record_batch_reader(
             yield first
             while True:
                 nxt = _fetch_one_batch(cursor_handle, pa, compact)
-                if cursor_handle._reset_seq != seen_seq:
+                if cursor_handle._reset_sequence() != seen_seq:
                     # Mid-query failover after batches were already
                     # yielded: the replayed batch-0 would duplicate what
                     # the consumer holds. Streaming can't discard it, so
@@ -300,9 +330,11 @@ cdef void _mark_reader_drained(_CursorHandle cursor_handle) noexcept:
     """
     if cursor_handle is None:
         return
-    cdef _ReaderHandle reader = cursor_handle._reader_ref
-    if reader is not None:
-        reader._must_close = False
+    cdef _ReaderHandle reader
+    with cursor_handle._lock:
+        reader = cursor_handle._reader_ref
+        if reader is not None:
+            reader._must_close = False
 
 
 cdef void_int _drain_cursor(_CursorHandle handle) except -1:
@@ -413,8 +445,11 @@ cdef void _failover_reset_trampoline(
     # arrives. Honour the C reentrancy contract: no reentrant FFI on the
     # reader/query/cursor, no exception escapes, non-blocking. user_data is
     # a raw int* at the cursor's _reset_seq counter; bumping it is a plain
-    # pointer write (no GIL, no Python object touched), which the
-    # materialise-whole accumulator polls to discard its pre-failover batches.
+    # pointer write (no GIL, no Python object touched). Once the handle is
+    # published, every cursor drive call holds its RLock, so this write is
+    # covered by the same cross-thread hand-off boundary as the native call.
+    # The materialise-whole accumulator polls it to discard its pre-failover
+    # batches.
     if user_data == NULL:
         return
     (<int*>user_data)[0] += 1
@@ -484,7 +519,7 @@ cdef void_int _bind_query_params(qwp_reader_query* query, object binds) except -
 
 cdef _CursorHandle _execute_query(
         _ReaderHandle reader_handle, str sql, object binds,
-        bint reset_symbol_dict=True):
+        bint reset_symbol_dict=True, bint owns_reader=True):
     """Execute a SQL query and return a _CursorHandle.
 
     The query is prepared with an ``on_failover_reset`` trampoline that
@@ -552,7 +587,7 @@ cdef _CursorHandle _execute_query(
                 'qwp_reader_query_execute returned NULL without setting err')
         raise _reader_err_to_py(err)
 
-    handle._attach(cursor, reader_handle)
+    handle._attach(cursor, reader_handle, owns_reader)
     return handle
 
 
@@ -764,6 +799,7 @@ cdef int _qs_pull_impl(_QueryStreamProducer prod):
     cdef questdb_error_code code
     cdef object py_msg
     cdef bytes full
+    cdef int current_seq
     if prod.exhausted:
         # A prior error left a diagnostic pinned; keep surfacing it rather
         # than reporting a clean end-of-stream to a consumer that pulls again.
@@ -786,7 +822,8 @@ cdef int _qs_pull_impl(_QueryStreamProducer prod):
             result = qwp_reader_cursor_next_arrow_batch_compact(
                 cursor, &local_array, &local_schema, &err)
     if result == qwp_reader_arrow_batch_ok:
-        if prod.cursor_handle._reset_seq != prod.seen_seq:
+        current_seq = prod.cursor_handle._reset_sequence()
+        if current_seq != prod.seen_seq:
             if prod.delivered:
                 # Mid-query failover replayed from batch-0 after batches
                 # were already handed to the consumer; this one would
@@ -811,7 +848,7 @@ cdef int _qs_pull_impl(_QueryStreamProducer prod):
                 return -1
             # Pre-delivery failover: nothing reached the consumer yet, so
             # re-pin to the replayed stream and restart from this batch-0.
-            prod.seen_seq = prod.cursor_handle._reset_seq
+            prod.seen_seq = current_seq
             prod._free_cached()
         if not prod.has_cached_schema:
             memcpy(&prod.cached_schema, &local_schema, sizeof(ArrowSchema))
@@ -826,8 +863,7 @@ cdef int _qs_pull_impl(_QueryStreamProducer prod):
         return 0
     if result == qwp_reader_arrow_batch_end:
         prod.exhausted = True
-        if prod.cursor_handle._reader_ref is not None:
-            prod.cursor_handle._reader_ref._must_close = False
+        _mark_reader_drained(prod.cursor_handle)
         return 0
     if err != NULL:
         code = questdb_error_get_code(err)
@@ -959,7 +995,7 @@ cdef object _make_query_stream_capsule(_CursorHandle handle):
     cdef ArrowArrayStream* stream
     prod = _QueryStreamProducer()
     prod.cursor_handle = handle
-    prod.seen_seq = handle._reset_seq
+    prod.seen_seq = handle._reset_sequence()
     stream = <ArrowArrayStream*>calloc(1, sizeof(ArrowArrayStream))
     if stream == NULL:
         raise MemoryError()
@@ -1776,9 +1812,9 @@ cdef object _numpy_frame_from_cursor(_CursorHandle handle):
     cdef bint has_symbol = False
     cdef int seen_seq
 
-    if handle is None or handle._cursor == NULL:
+    if handle is None or not handle._is_live():
         raise QuestDBError(QuestDBErrorCode.InvalidApiCall, 'cursor is closed')
-    seen_seq = handle._reset_seq
+    seen_seq = handle._reset_sequence()
 
     col_names = []
     col_kinds = []
@@ -2072,7 +2108,8 @@ cdef class _NumpyBatchIter:
         self.prev_dict_n = 0
         self.symbol_categories = []
         self.symbol_dtype = None
-        self.seen_seq = handle._reset_seq if handle is not None else 0
+        self.seen_seq = (
+            handle._reset_sequence() if handle is not None else 0)
         self.delivered = False
 
     def __iter__(self):
@@ -2085,7 +2122,10 @@ cdef class _NumpyBatchIter:
         cdef qwp_reader_symbol_dict sd
         cdef size_t row_count
         cdef size_t n_cols
-        if self.done or self.handle is None or self.handle._cursor == NULL:
+        if (
+                self.done
+                or self.handle is None
+                or not self.handle._is_live()):
             raise StopIteration
         try:
             with self.handle._lock:
@@ -2208,7 +2248,7 @@ def _debug_egress_pool_stats(client):
 
 
 cdef bint _cursor_handle_is_live(_CursorHandle h):
-    return h is not None and h._cursor != NULL
+    return h is not None and h._is_live()
 
 
 class QueryResult:
@@ -2225,11 +2265,11 @@ class QueryResult:
     Closing a partial result drops its connection. Call :meth:`cancel`
     before closing to preserve it.
 
-    **Thread affinity**: the underlying cursor is bound to the thread that
-    created it (via ``QuestDB.query``). Create, consume, ``cancel``,
-    ``close``, and drop the ``QueryResult`` on that same thread; handing it
-    to another thread is undefined behaviour even with external
-    synchronisation.
+    **Thread hand-off**: a ``QueryResult`` may be transferred to another
+    thread and consumed, cancelled, closed, or dropped there. Use a normal
+    synchronisation hand-off (for example, ``Thread.start`` / ``join`` or a
+    thread-safe queue), and access it from only one thread at a time.
+    Concurrent operations on one result are unsupported.
 
     ``__arrow_c_stream__`` is native — the cursor's record batches are
     exposed directly through the Arrow C Data Interface, so polars /
@@ -2286,11 +2326,10 @@ class QueryResult:
         it references — so a consumer that unifies per-batch dictionaries
         (e.g. ``polars.from_arrow``) reconciles them.
 
-        The returned stream wraps the query cursor, which has thread
-        affinity in the underlying FFI: consume it from one thread at a
-        time, preferably the thread that ran the query. Cross-thread
-        consumption is currently serialised by an internal lock, but the
-        FFI contract does not guarantee that indefinitely.
+        The returned stream may be handed to a consumer worker thread.
+        Stream callbacks are serialised by the same cursor lock, but the
+        Arrow C stream itself must still be consumed by only one thread at
+        a time; concurrent ``get_next`` / ``release`` calls are unsupported.
         """
         if requested_schema is not None:
             raise NotImplementedError(
@@ -2520,13 +2559,11 @@ class QueryResult:
 
     def __del__(self):
         cdef _CursorHandle handle
-        cdef _ReaderHandle reader
         try:
             handle = self._cursor_handle
             if not _cursor_handle_is_live(handle):
                 return
-            reader = handle._reader_ref
-            if reader is None or reader._must_close:
+            if handle._abandonment_needs_warning():
                 warnings.warn(
                     'QueryResult was neither drained nor closed; its '
                     'pooled connection is being released by the garbage '

--- a/src/questdb/egress.pxi
+++ b/src/questdb/egress.pxi
@@ -263,8 +263,10 @@ cdef tuple _fetch_all_record_batches(
     except:
         handle._free()
         raise
-    _mark_reader_drained(handle)
-    handle._free()
+    try:
+        _mark_reader_drained(handle)
+    finally:
+        handle._free()
     return (schema, batches)
 
 
@@ -285,8 +287,10 @@ cdef object _build_record_batch_reader(
         # No result set (a non-SELECT statement ends with EXEC_DONE and
         # ships no RESULT_BATCH), so there is no schema to surface; an
         # empty SELECT still ships a zero-row batch carrying the schema.
-        _mark_reader_drained(cursor_handle)
-        cursor_handle._free()
+        try:
+            _mark_reader_drained(cursor_handle)
+        finally:
+            cursor_handle._free()
         empty = pa.table({})
         return empty.to_reader()
 
@@ -321,7 +325,8 @@ cdef object _build_record_batch_reader(
     return pa.RecordBatchReader.from_batches(schema, _gen(compact))
 
 
-cdef void _mark_reader_drained(_CursorHandle cursor_handle) noexcept:
+cdef void_int _mark_reader_drained(
+        _CursorHandle cursor_handle) except -1:
     """Tell the reader handle it's safe to return to its pool on dealloc.
 
     The Rust Cursor::Drop closes the underlying transport whenever
@@ -330,12 +335,13 @@ cdef void _mark_reader_drained(_CursorHandle cursor_handle) noexcept:
     borrower would see a broken pipe.
     """
     if cursor_handle is None:
-        return
+        return 0
     cdef _ReaderHandle reader
     with cursor_handle._lock:
         reader = cursor_handle._reader_ref
         if reader is not None:
             reader._must_close = False
+    return 0
 
 
 cdef void_int _drain_cursor(_CursorHandle handle) except -1:
@@ -354,8 +360,10 @@ cdef void_int _drain_cursor(_CursorHandle handle) except -1:
             if err != NULL:
                 raise _reader_err_to_py(err)
             break
-    _mark_reader_drained(handle)
-    handle._free()
+    try:
+        _mark_reader_drained(handle)
+    finally:
+        handle._free()
 
 
 cdef _ReaderHandle _borrow_reader_from_pool(questdb_db* db):
@@ -1873,8 +1881,10 @@ cdef object _numpy_frame_from_cursor(_CursorHandle handle):
         handle._free()
         raise
 
-    _mark_reader_drained(handle)
-    handle._free()
+    try:
+        _mark_reader_drained(handle)
+    finally:
+        handle._free()
 
     if first:
         return pd.DataFrame()
@@ -2514,7 +2524,7 @@ class QueryResult:
         cdef bint ok
         cdef bint reusable
         cdef qwp_reader_cursor* cursor
-        cdef object exc
+        cdef object exc = None
         if handle is None:
             return
         with handle._lock:
@@ -2524,16 +2534,24 @@ class QueryResult:
             with nogil:
                 ok = qwp_reader_cursor_cancel(cursor, &err)
                 reusable = qwp_reader_cursor_connection_reusable(cursor)
-        if reusable:
-            _mark_reader_drained(handle)
         if not ok:
             if err != NULL:
                 exc = _reader_err_to_py(err)
+                err = NULL
             else:
                 exc = QuestDBError(
                     QuestDBErrorCode.ServerFlushError,
                     'qwp_reader_cursor_cancel returned false '
                     'without setting err_out')
+        if reusable:
+            try:
+                _mark_reader_drained(handle)
+            except BaseException as mark_exc:
+                self.close()
+                if exc is not None:
+                    raise exc from mark_exc
+                raise
+        if exc is not None:
             self.close()
             raise exc
 

--- a/src/questdb/line_sender.pxd
+++ b/src/questdb/line_sender.pxd
@@ -57,7 +57,7 @@ cdef extern from "questdb/ingress/line_sender.h":
         line_sender_error_failover_retry,
         line_sender_error_role_mismatch,
         line_sender_error_connect_timeout,
-        # Query / reader (egress) categories, unified into this enum (20..36).
+        # Query / reader (egress) categories, unified into this enum (20..37).
         line_sender_error_handshake_error,
         line_sender_error_unsupported_server,
         line_sender_error_protocol_error,
@@ -74,7 +74,8 @@ cdef extern from "questdb/ingress/line_sender.h":
         line_sender_error_no_schema,
         line_sender_error_arrow_export,
         line_sender_error_batch_too_large,
-        line_sender_error_store_resend_required
+        line_sender_error_store_resend_required,
+        line_sender_error_symbol_dict_full
 
     ctypedef line_sender_error_code questdb_error_code
 

--- a/src/questdb/line_sender.pxd
+++ b/src/questdb/line_sender.pxd
@@ -57,7 +57,7 @@ cdef extern from "questdb/ingress/line_sender.h":
         line_sender_error_failover_retry,
         line_sender_error_role_mismatch,
         line_sender_error_connect_timeout,
-        # Query / reader (egress) categories, unified into this enum (20..37).
+        # Query / reader error codes (20..34).
         line_sender_error_handshake_error,
         line_sender_error_unsupported_server,
         line_sender_error_protocol_error,
@@ -73,6 +73,7 @@ cdef extern from "questdb/ingress/line_sender.h":
         line_sender_error_schema_drift,
         line_sender_error_no_schema,
         line_sender_error_arrow_export,
+        # Client-side QWP/WebSocket sender error codes (35..37).
         line_sender_error_batch_too_large,
         line_sender_error_store_resend_required,
         line_sender_error_symbol_dict_full

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -3282,9 +3282,9 @@ class TestEgressPool(unittest.TestCase):
             ('private_data', ctypes.c_void_p),
         ]
         ArrowSchema._fields_ = [
-            ('format', ctypes.c_char_p),
-            ('name', ctypes.c_char_p),
-            ('metadata', ctypes.c_char_p),
+            ('format', ctypes.c_void_p),
+            ('name', ctypes.c_void_p),
+            ('metadata', ctypes.c_void_p),
             ('flags', ctypes.c_int64),
             ('n_children', ctypes.c_int64),
             ('children', ctypes.POINTER(ctypes.POINTER(ArrowSchema))),

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -3252,6 +3252,175 @@ class TestEgressPool(unittest.TestCase):
                 f'expected 1 idle reader cached across 5 queries; '
                 f'got in_use={in_use}, idle={idle}')
 
+    def test_arrow_capsule_callbacks_migrate_between_workers(self):
+        """Drive one Arrow C stream through two synchronized worker
+        threads: worker A fetches schema + the first batch, worker B
+        drains and releases it. This pins the actual third-party callback
+        route, including foreign-thread ``qwp_reader_cursor_free``.
+        """
+        import ctypes
+
+        class ArrowArray(ctypes.Structure):
+            pass
+
+        class ArrowSchema(ctypes.Structure):
+            pass
+
+        class ArrowArrayStream(ctypes.Structure):
+            pass
+
+        ArrowArray._fields_ = [
+            ('length', ctypes.c_int64),
+            ('null_count', ctypes.c_int64),
+            ('offset', ctypes.c_int64),
+            ('n_buffers', ctypes.c_int64),
+            ('n_children', ctypes.c_int64),
+            ('buffers', ctypes.POINTER(ctypes.c_void_p)),
+            ('children', ctypes.POINTER(ctypes.POINTER(ArrowArray))),
+            ('dictionary', ctypes.POINTER(ArrowArray)),
+            ('release', ctypes.c_void_p),
+            ('private_data', ctypes.c_void_p),
+        ]
+        ArrowSchema._fields_ = [
+            ('format', ctypes.c_char_p),
+            ('name', ctypes.c_char_p),
+            ('metadata', ctypes.c_char_p),
+            ('flags', ctypes.c_int64),
+            ('n_children', ctypes.c_int64),
+            ('children', ctypes.POINTER(ctypes.POINTER(ArrowSchema))),
+            ('dictionary', ctypes.POINTER(ArrowSchema)),
+            ('release', ctypes.c_void_p),
+            ('private_data', ctypes.c_void_p),
+        ]
+        ArrowArrayStream._fields_ = [
+            ('get_schema', ctypes.c_void_p),
+            ('get_next', ctypes.c_void_p),
+            ('get_last_error', ctypes.c_void_p),
+            ('release', ctypes.c_void_p),
+            ('private_data', ctypes.c_void_p),
+        ]
+
+        stream_ptr_t = ctypes.POINTER(ArrowArrayStream)
+        get_schema_t = ctypes.CFUNCTYPE(
+            ctypes.c_int,
+            stream_ptr_t,
+            ctypes.POINTER(ArrowSchema))
+        get_next_t = ctypes.CFUNCTYPE(
+            ctypes.c_int,
+            stream_ptr_t,
+            ctypes.POINTER(ArrowArray))
+        stream_release_t = ctypes.CFUNCTYPE(None, stream_ptr_t)
+        schema_release_t = ctypes.CFUNCTYPE(
+            None, ctypes.POINTER(ArrowSchema))
+        array_release_t = ctypes.CFUNCTYPE(
+            None, ctypes.POINTER(ArrowArray))
+
+        table = self._seed_table(n_rows=64)
+        with qi.QuestDB.from_conf(self._conf()) as client:
+            result = client.query(f'SELECT x FROM {table} ORDER BY x')
+            capsule = result.__arrow_c_stream__()
+            capsule_get = ctypes.pythonapi.PyCapsule_GetPointer
+            capsule_get.argtypes = [ctypes.py_object, ctypes.c_char_p]
+            capsule_get.restype = ctypes.c_void_p
+            stream_addr = capsule_get(capsule, b'arrow_array_stream')
+            self.assertTrue(stream_addr)
+            stream = ctypes.cast(stream_addr, stream_ptr_t)
+
+            ready = threading.Event()
+            finished = threading.Event()
+            errors = []
+            worker_ids = []
+            row_counts = []
+
+            def release_schema(schema):
+                if schema.release:
+                    schema_release_t(schema.release)(
+                        ctypes.byref(schema))
+
+            def release_array(array):
+                if array.release:
+                    array_release_t(array.release)(
+                        ctypes.byref(array))
+
+            def worker_a():
+                worker_ids.append(('a', threading.get_ident()))
+                try:
+                    schema = ArrowSchema()
+                    get_schema = get_schema_t(
+                        stream.contents.get_schema)
+                    rc = get_schema(stream, ctypes.byref(schema))
+                    if rc != 0:
+                        raise RuntimeError(f'get_schema returned {rc}')
+                    if not schema.release:
+                        raise RuntimeError(
+                            'get_schema returned no release callback')
+                    release_schema(schema)
+
+                    array = ArrowArray()
+                    get_next = get_next_t(stream.contents.get_next)
+                    rc = get_next(stream, ctypes.byref(array))
+                    if rc != 0:
+                        raise RuntimeError(f'first get_next returned {rc}')
+                    if array.release:
+                        row_counts.append(array.length)
+                        release_array(array)
+                except BaseException as exc:
+                    errors.append(('a', repr(exc)))
+                finally:
+                    ready.set()
+                    finished.wait(timeout=30)
+
+            def worker_b():
+                if not ready.wait(timeout=30):
+                    errors.append(('b', 'worker A did not publish'))
+                    finished.set()
+                    return
+                worker_ids.append(('b', threading.get_ident()))
+                try:
+                    if not errors:
+                        get_next = get_next_t(stream.contents.get_next)
+                        while True:
+                            array = ArrowArray()
+                            rc = get_next(stream, ctypes.byref(array))
+                            if rc != 0:
+                                raise RuntimeError(
+                                    f'drain get_next returned {rc}')
+                            if not array.release:
+                                break
+                            row_counts.append(array.length)
+                            release_array(array)
+                except BaseException as exc:
+                    errors.append(('b', repr(exc)))
+                finally:
+                    if stream.contents.release:
+                        stream_release_t(stream.contents.release)(stream)
+                    finished.set()
+
+            thread_a = threading.Thread(target=worker_a)
+            thread_b = threading.Thread(target=worker_b)
+            thread_a.start()
+            thread_b.start()
+            thread_a.join(timeout=30)
+            thread_b.join(timeout=30)
+            self.assertFalse(thread_a.is_alive(), 'worker A hung')
+            self.assertFalse(thread_b.is_alive(), 'worker B hung')
+            self.assertEqual(errors, [])
+            self.assertEqual(sum(row_counts), 64)
+            self.assertEqual(len(worker_ids), 2)
+            self.assertNotEqual(worker_ids[0][1], worker_ids[1][1])
+            self.assertNotIn(
+                threading.get_ident(), [ident for _, ident in worker_ids])
+
+            # Worker B released the producer and returned the clean reader.
+            # The capsule destructor now only frees its tiny stream struct.
+            result.close()
+            del capsule
+            self.assertEqual(
+                qi._debug_egress_pool_stats(client), (0, 1))
+            after = client.query(
+                f'SELECT count() FROM {table}').to_arrow()
+            self.assertEqual(after.column(0).to_pylist(), [64])
+
     def test_server_info_recycles_pooled_reader(self):
         """server_info() borrows a pristine reader (no cursor, no wire
         traffic) and must return it to the pool, not drop it."""
@@ -3403,30 +3572,52 @@ class TestEgressPool(unittest.TestCase):
     def test_gc_abandoned_result_warns_and_releases(self):
         """A never-consumed ``QueryResult`` abandoned inside a
         reference cycle holds its reader until the garbage collector
-        runs; the ``__del__`` backstop then emits a ``ResourceWarning``
-        and releases the reader. The cycle keeps refcounting from
-        cleaning it up early, so this observes the true GC-timed path.
+        runs on a worker thread; the ``__del__`` backstop then emits a
+        ``ResourceWarning`` and releases the reader on that worker. The
+        cycle keeps refcounting from cleaning it up early, so this
+        observes the true GC-timed cross-thread path.
         """
         import gc
         import warnings
         table = self._seed_table(n_rows=64)
         with qi.QuestDB.from_conf(self._conf()) as client:
-            result = client.query(f'SELECT x FROM {table} ORDER BY x')
-            result._cycle = result
-            in_use, _ = qi._debug_egress_pool_stats(client)
-            self.assertEqual(in_use, 1)
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter('always')
-                del result
+            gc_was_enabled = gc.isenabled()
+            gc.disable()
+            try:
+                result = client.query(
+                    f'SELECT x FROM {table} ORDER BY x')
+                result._cycle = result
                 in_use, _ = qi._debug_egress_pool_stats(client)
-                self.assertEqual(
-                    in_use, 1,
-                    'the cycle should defer release until gc runs')
-                gc.collect()
+                self.assertEqual(in_use, 1)
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter('always')
+                    del result
+                    in_use, _ = qi._debug_egress_pool_stats(client)
+                    self.assertEqual(
+                        in_use, 1,
+                        'the cycle should defer release until gc runs')
+                    collector_threads = []
+
+                    def collect_abandoned():
+                        collector_threads.append(threading.get_ident())
+                        gc.collect()
+
+                    collector = threading.Thread(target=collect_abandoned)
+                    collector.start()
+                    collector.join(timeout=30)
+                    self.assertFalse(
+                        collector.is_alive(), 'worker gc.collect() hung')
+            finally:
+                if gc_was_enabled:
+                    gc.enable()
+
+            self.assertEqual(len(collector_threads), 1)
+            self.assertNotEqual(
+                collector_threads[0], threading.get_ident())
             in_use, idle = qi._debug_egress_pool_stats(client)
             self.assertEqual(
                 (in_use, idle), (0, 0),
-                f'gc backstop did not release the reader; '
+                f'worker GC backstop did not release the reader; '
                 f'got in_use={in_use}, idle={idle}')
             resource_warnings = [
                 w for w in caught
@@ -3437,6 +3628,12 @@ class TestEgressPool(unittest.TestCase):
             self.assertIn(
                 'neither drained nor closed',
                 str(resource_warnings[0].message))
+
+            # The foreign-thread finalizer dropped the partial connection;
+            # the next query must open a fresh one successfully.
+            after = client.query(
+                f'SELECT count() FROM {table}').to_arrow()
+            self.assertEqual(after.column(0).to_pylist(), [64])
 
     def test_abandoned_iterator_releases_reader_on_del(self):
         """Abandoning a partially-consumed stream releases the reader
@@ -3547,6 +3744,44 @@ class TestEgressPool(unittest.TestCase):
                 (in_use, idle), (0, 1),
                 f'close() must return the drained reader to the pool; '
                 f'got in_use={in_use}, idle={idle}')
+
+    def test_query_lease_result_handoff_to_worker_then_next_query(self):
+        """The lease stays on its creating thread while one result moves
+        to a worker. Joining that worker publishes the drained cursor
+        before the lease starts its next query on the same reader.
+        """
+        table = self._seed_table(n_rows=64)
+        with qi.QuestDB.from_conf(self._conf()) as client:
+            with client.reader() as lease:
+                result = lease.query(
+                    f'SELECT x FROM {table} ORDER BY x')
+                worker_values = []
+                worker_errors = []
+                worker_ids = []
+
+                def consume_result():
+                    worker_ids.append(threading.get_ident())
+                    try:
+                        worker_values.extend(
+                            result.to_arrow().column('x').to_pylist())
+                    except BaseException as exc:
+                        worker_errors.append(repr(exc))
+
+                worker = threading.Thread(target=consume_result)
+                worker.start()
+                worker.join(timeout=30)
+                self.assertFalse(worker.is_alive(), 'result worker hung')
+                self.assertEqual(worker_errors, [])
+                self.assertNotEqual(
+                    worker_ids, [threading.get_ident()])
+                self.assertEqual(worker_values, list(range(64)))
+
+                after = lease.query(
+                    f'SELECT count() FROM {table}').to_arrow()
+                self.assertEqual(after.column(0).to_pylist(), [64])
+
+            self.assertEqual(
+                qi._debug_egress_pool_stats(client), (0, 1))
 
     def test_query_lease_reset_symbol_dict_false(self):
         """A follow-up lease query with ``reset_symbol_dict=False``

--- a/test/test.py
+++ b/test/test.py
@@ -374,16 +374,18 @@ class TestQwpWebSocketApi(unittest.TestCase):
             qi.QuestDB.from_conf('ws::sender_pool_min=1;')
 
     def test_removed_qwp_flight_window_keys_are_rejected(self):
-        for key in ('max_in_flight', 'in_flight_window'):
-            with self.subTest(key=key):
-                with self.assertRaisesRegex(
-                        qi.QuestDBError,
-                        f'Unknown config key "{key}"') as cm:
-                    qi.Sender.from_conf(
-                        f'ws::addr=127.0.0.1:1;lazy_connect=true;{key}=1;')
-                self.assertIs(
-                    cm.exception.code,
-                    qi.QuestDBErrorCode.ConfigError)
+        for scheme in ('ws', 'wss'):
+            for key in ('max_in_flight', 'in_flight_window'):
+                with self.subTest(scheme=scheme, key=key):
+                    with self.assertRaisesRegex(
+                            qi.QuestDBError,
+                            f'Unknown config key "{key}"') as cm:
+                        qi.Sender.from_conf(
+                            f'{scheme}::addr=127.0.0.1:1;'
+                            f'lazy_connect=true;{key}=1;')
+                    self.assertIs(
+                        cm.exception.code,
+                        qi.QuestDBErrorCode.ConfigError)
 
     def test_client_close_is_idempotent(self):
         client = qi.QuestDB.__new__(qi.QuestDB)

--- a/test/test.py
+++ b/test/test.py
@@ -308,6 +308,10 @@ class TestQwpWebSocketApi(unittest.TestCase):
         self.assertEqual(
             qi.QuestDBErrorCode.StoreResendRequired.value,
             36)
+        self.assertEqual(qi.QuestDBErrorCode.SymbolDictFull.value, 37)
+        self.assertIs(
+            qi._debug_error_code_to_py(37),
+            qi.QuestDBErrorCode.SymbolDictFull)
 
     def test_default_max_chunk_rows_matches_core_literal(self):
         # Pinned to the Rust core's DEFAULT_MAX_CHUNK_ROWS. Both sides hardcode
@@ -368,6 +372,18 @@ class TestQwpWebSocketApi(unittest.TestCase):
                 qi.QuestDBError,
                 'Missing "addr" parameter'):
             qi.QuestDB.from_conf('ws::sender_pool_min=1;')
+
+    def test_removed_qwp_flight_window_keys_are_rejected(self):
+        for key in ('max_in_flight', 'in_flight_window'):
+            with self.subTest(key=key):
+                with self.assertRaisesRegex(
+                        qi.QuestDBError,
+                        f'Unknown config key "{key}"') as cm:
+                    qi.Sender.from_conf(
+                        f'ws::addr=127.0.0.1:1;lazy_connect=true;{key}=1;')
+                self.assertIs(
+                    cm.exception.code,
+                    qi.QuestDBErrorCode.ConfigError)
 
     def test_client_close_is_idempotent(self):
         client = qi.QuestDB.__new__(qi.QuestDB)
@@ -1377,11 +1393,9 @@ class TestQwpWebSocketApi(unittest.TestCase):
         rejection stream must overflow the inbox and count drops.
 
         Status 0x0C (not-writable) maps to the RetriableOther policy,
-        which replays the frame with no backoff — every replay is
-        rejected again, so events flow while the handler is blocked.
-        The stream is bounded by the native max_frame_rejections
-        default (4 strikes, then a terminal event): one event more than
-        the 3 a drop needs, so a lower default would starve this test.
+        so the same frame is replayed without consuming poison strikes.
+        A 1 ms reconnect backoff keeps that replay deterministic and fast
+        while the handler remains blocked.
         """
         release = threading.Event()
         first_delivered = threading.Event()
@@ -1397,6 +1411,9 @@ class TestQwpWebSocketApi(unittest.TestCase):
                 'sender_pool_max=1;'
                 'pool_reap=manual;'
                 'close_flush_timeout_millis=0;')
+            conf += (
+                'reconnect_initial_backoff_millis=1;'
+                'reconnect_max_backoff_millis=1;')
             with qi.QuestDB.from_conf(
                     conf,
                     error_handler=on_error,
@@ -1428,23 +1445,23 @@ class TestQwpWebSocketApi(unittest.TestCase):
     def test_standalone_sender_error_ring_overflow_counts_drops(self):
         """A standalone ws sender's per-connection diagnostic ring
         (``error_inbox_capacity``, minimum 16) must evict oldest un-polled
-        diagnostics and count them once a rejection storm outruns polling.
-        Status 0x0C replays each frame up to 4 strikes before its terminal
-        event, so 8 frames yield well over 16 diagnostics."""
+        diagnostics and count them once a replayable rejection outruns
+        polling. Status 0x0C is strike-exempt, so one frame is enough."""
         with QwpAckServer(error_status=0x0C) as server:
             conf = (
                 f'ws::addr=127.0.0.1:{server.port};lazy_connect=true;'
                 'error_inbox_capacity=16;'
                 'close_flush_timeout_millis=0;'
+                'reconnect_initial_backoff_millis=1;'
+                'reconnect_max_backoff_millis=1;'
                 'reconnect_max_duration_millis=30000;')
             sender = qi.Sender.from_conf(conf)
             try:
                 sender.establish()
-                for i in range(8):
-                    sender.row(
-                        'events', columns={'value': i},
-                        at=qi.ServerTimestamp)
-                    sender.flush()
+                sender.row(
+                    'events', columns={'value': 1},
+                    at=qi.ServerTimestamp)
+                sender.flush()
                 deadline = time.monotonic() + 15
                 while sender.error_events_dropped() < 1:
                     self.assertLess(

--- a/test/test.py
+++ b/test/test.py
@@ -924,7 +924,7 @@ class TestQwpWebSocketApi(unittest.TestCase):
                         'events', columns={'value': 'x' * (8 * 1024 * 1024)},
                         at=qi.ServerTimestamp)
                     self.assertEqual(len(sender), 0)
-                    sender.wait(5000)
+                    sender.wait(30000)
 
             stats = server.snapshot()
 


### PR DESCRIPTION
Updates the Python client for the latest QWP behavior:
- Query results can be handed safely to worker threads.
- Long-lived connections report when their symbol dictionary is full and pooled clients replace the connection.
- Failed DataFrame loads discard uncommitted rows. Earlier checkpoints may remain.
- Disk-backed ingestion recovers more safely after crashes.
- `max_in_flight` and `in_flight_window` are no longer supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `SymbolDictFull` error reporting when WebSocket symbol dictionaries reach capacity.
  - Enabled safer cross-thread query-result handoff, including Arrow streams.
  - Improved recovery and duplicate handling after connection or reader resets.

- **Bug Fixes**
  - Improved DataFrame load cleanup, checkpointing, and partial-commit behavior.
  - Strengthened disk-backed delivery shutdown and crash recovery.

- **Documentation**
  - Documented DataFrame retry and duplicate-row considerations.
  - Removed obsolete WebSocket flight-window settings; unsupported settings are now rejected at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->