### PR TITLE
Automate Python client releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
       release_sha: ${{ steps.release.outputs.release_sha }}
+      pr_head_sha: ${{ steps.release.outputs.pr_head_sha }}
     steps:
       - name: Validate dispatch and release pull request
         id: release
@@ -62,10 +63,12 @@ jobs:
               exit 1
             }
           release_sha="$(jq -er '.merge_commit_sha | select(test("^[0-9a-f]{40}$"))' <<<"$pr_json")"
+          pr_head_sha="$(jq -er '.head.sha | select(test("^[0-9a-f]{40}$"))' <<<"$pr_json")"
           {
             echo "version=$RELEASE_VERSION"
             echo "tag=v$RELEASE_VERSION"
             echo "release_sha=$release_sha"
+            echo "pr_head_sha=$pr_head_sha"
           } >>"$GITHUB_OUTPUT"
 
       - name: Check out the release commit
@@ -135,6 +138,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_PR: ${{ inputs.release_pr }}
+          PR_HEAD_SHA: ${{ steps.release.outputs.pr_head_sha }}
         run: |
           set -Eeuo pipefail
           source_root="$RUNNER_TEMP/release-sources/github-macos-arm64"
@@ -146,16 +150,17 @@ jobs:
             "/repos/$GITHUB_REPOSITORY/actions/workflows/macos-arm64-wheels.yml/runs?event=pull_request&status=success&per_page=100" \
             --jq '.workflow_runs[]' \
             >"$RUNNER_TEMP/macos-runs.jsonl"
-          run_json="$(jq -cs --argjson pr "$RELEASE_PR" '
+          run_json="$(jq -cs --argjson pr "$RELEASE_PR" --arg head "$PR_HEAD_SHA" '
             [.[]
              | select(.event == "pull_request"
                       and .status == "completed"
                       and .conclusion == "success"
+                      and .head_sha == $head
                       and any(.pull_requests[]?; .number == $pr))]
             | sort_by(.created_at, .id) | reverse | .[0] // empty
           ' "$RUNNER_TEMP/macos-runs.jsonl")"
           [[ -n "$run_json" ]] || {
-            echo "No successful macOS arm64 pull_request run found for PR $RELEASE_PR" >&2
+            echo "No successful macOS arm64 pull_request run found for PR $RELEASE_PR head $PR_HEAD_SHA" >&2
             exit 1
           }
           run_id="$(jq -er '.id' <<<"$run_json")"
@@ -164,9 +169,14 @@ jobs:
           artifacts="$(gh api \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts?name=wheels-macos-arm64&per_page=100")"
-          artifact="$(jq -c '[.artifacts[] | select(.name == "wheels-macos-arm64")] |
-            if length == 1 then .[0] else error("expected exactly one wheels-macos-arm64 artifact") end' \
-            <<<"$artifacts")"
+          artifact="$(jq -c --arg head "$PR_HEAD_SHA" '
+            [.artifacts[]
+             | select(.name == "wheels-macos-arm64"
+                      and .workflow_run.head_sha == $head)]
+            | if length == 1 then .[0]
+              else error("expected exactly one wheels-macos-arm64 artifact for validated PR head")
+              end
+          ' <<<"$artifacts")"
           jq -e '.expired == false' <<<"$artifact" >/dev/null || {
             echo "wheels-macos-arm64 artifact for run $run_id is expired" >&2
             exit 1
@@ -187,6 +197,7 @@ jobs:
         env:
           AZURE_DEVOPS_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
           RELEASE_PR: ${{ inputs.release_pr }}
+          PR_HEAD_SHA: ${{ steps.release.outputs.pr_head_sha }}
         run: |
           set -Eeuo pipefail
           source_root="$RUNNER_TEMP/release-sources/azure-drop"
@@ -206,17 +217,22 @@ jobs:
             --data-urlencode '$top=10' \
             --data-urlencode 'api-version=7.1' \
             "$builds_url")"
-          build="$(jq -c --arg branch "$branch" '
+          build="$(jq -c \
+            --arg branch "$branch" \
+            --arg head "$PR_HEAD_SHA" \
+            --arg pr "$RELEASE_PR" '
             [.value[]
              | select(.definition.id == 21
                       and .sourceBranch == $branch
                       and .reason == "pullRequest"
                       and .status == "completed"
-                      and .result == "succeeded")]
+                      and .result == "succeeded"
+                      and .triggerInfo["pr.sourceSha"] == $head
+                      and .triggerInfo["pr.number"] == $pr)]
             | sort_by(.finishTime, .id) | reverse | .[0] // empty
           ' <<<"$builds_json")"
           [[ -n "$build" ]] || {
-            echo "No successful Azure definition 21 build found for $branch" >&2
+            echo "No successful Azure definition 21 build found for $branch head $PR_HEAD_SHA" >&2
             exit 1
           }
           build_id="$(jq -er '.id' <<<"$build")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,11 @@ jobs:
         with:
           ref: ${{ steps.release.outputs.release_sha }}
           fetch-depth: 0
-          submodules: recursive
+
+      - name: Initialize release source submodule
+        run: |
+          set -Eeuo pipefail
+          git submodule update --init c-questdb-client
 
       - name: Verify release commit ancestry
         run: |
@@ -318,6 +322,13 @@ jobs:
           sdist_name, sdist_version = parse_sdist_filename(sdists[0].name)
           if canonicalize_name(sdist_name) != "questdb" or sdist_version != version:
               raise SystemExit(f"unexpected sdist identity: {sdists[0].name}")
+          max_sdist_size = 100 * 1024 * 1024
+          sdist_size = sdists[0].stat().st_size
+          if sdist_size >= max_sdist_size:
+              raise SystemExit(
+                  f"sdist {sdists[0].name} is {sdist_size} bytes; "
+                  f"must be below PyPI's {max_sdist_size}-byte per-file limit"
+              )
 
           with tarfile.open(sdists[0], "r:gz") as archive:
               members = archive.getmembers()
@@ -326,6 +337,14 @@ jobs:
                   path = Path(name)
                   if path.is_absolute() or ".." in path.parts:
                       raise SystemExit(f"unsafe sdist member path: {name}")
+                  if any(
+                      path.parts[index : index + 2] == ("c-questdb-client", "questdb")
+                      for index in range(len(path.parts) - 1)
+                  ):
+                      raise SystemExit(
+                          "sdist contains nested c-questdb-client/questdb/ submodule "
+                          f"content: {name}"
+                      )
               required_suffixes = (
                   "/PKG-INFO",
                   "/src/questdb/__init__.py",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,486 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version without the v prefix (for example, 5.0.1)
+        required: true
+        type: string
+      release_pr:
+        description: Merged version/changelog PR number
+        required: true
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
+      release_sha: ${{ steps.release.outputs.release_sha }}
+    steps:
+      - name: Validate dispatch and release pull request
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_PR: ${{ inputs.release_pr }}
+          DISPATCH_REF: ${{ github.ref }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$DISPATCH_REF" == refs/heads/main ]] || {
+            echo "Release workflow must be dispatched from main, not $DISPATCH_REF" >&2
+            exit 1
+          }
+          [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.-]+)?$ ]] || {
+            echo "Invalid version: $RELEASE_VERSION" >&2
+            exit 1
+          }
+          [[ "$RELEASE_PR" =~ ^[0-9]+$ ]] || {
+            echo "Invalid release PR number: $RELEASE_PR" >&2
+            exit 1
+          }
+
+          pr_json="$(gh api \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/$GITHUB_REPOSITORY/pulls/$RELEASE_PR")"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            '.merged == true and .base.ref == "main" and .head.repo.full_name == $repository' \
+            <<<"$pr_json" >/dev/null || {
+              echo "PR $RELEASE_PR must be merged into main from $GITHUB_REPOSITORY" >&2
+              exit 1
+            }
+          release_sha="$(jq -er '.merge_commit_sha | select(test("^[0-9a-f]{40}$"))' <<<"$pr_json")"
+          {
+            echo "version=$RELEASE_VERSION"
+            echo "tag=v$RELEASE_VERSION"
+            echo "release_sha=$release_sha"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Check out the release commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release.outputs.release_sha }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Verify release commit ancestry
+        run: |
+          set -Eeuo pipefail
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor HEAD origin/main || {
+            echo "Release commit is not reachable from origin/main" >&2
+            exit 1
+          }
+
+      - name: Validate version metadata and changelog
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          python - <<'PY'
+          import datetime
+          import re
+          import tomllib
+          from pathlib import Path
+
+          import os
+
+          version = os.environ["RELEASE_VERSION"]
+          config = tomllib.loads(Path(".bumpversion.toml").read_text())
+          bump = config["tool"]["bumpversion"]
+          if bump["current_version"] != version:
+              raise SystemExit(
+                  f".bumpversion.toml has {bump['current_version']!r}, expected {version!r}"
+              )
+          for entry in bump["files"]:
+              path = Path(entry["filename"])
+              expected = entry["search"].replace("{current_version}", version)
+              if expected not in path.read_text():
+                  raise SystemExit(f"{path} does not contain configured version literal {expected!r}")
+
+          lines = Path("CHANGELOG.rst").read_text().splitlines()
+          heading_re = re.compile(r"^(\d+\.\d+\.\d+(?:[a-zA-Z0-9.-]+)?) \(([^)]+)\)$")
+          first = next(((i, match) for i, line in enumerate(lines)
+                        if (match := heading_re.fullmatch(line))), None)
+          if first is None:
+              raise SystemExit("CHANGELOG.rst has no version heading")
+          index, match = first
+          expected_date = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+          if match.group(1) != version:
+              raise SystemExit(
+                  f"first changelog version is {match.group(1)!r}, expected {version!r}"
+              )
+          date = match.group(2)
+          if date.lower() == "unreleased" or date != expected_date:
+              raise SystemExit(
+                  f"changelog date is {date!r}, expected UTC date {expected_date!r}"
+              )
+          if index + 1 >= len(lines) or not re.fullmatch(r"-+", lines[index + 1]):
+              raise SystemExit(f"changelog heading for {version} has no RST underline")
+          PY
+
+      - name: Download macOS arm64 wheels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PR: ${{ inputs.release_pr }}
+        run: |
+          set -Eeuo pipefail
+          source_root="$RUNNER_TEMP/release-sources/github-macos-arm64"
+          rm -rf "$source_root"
+          mkdir -p "$source_root"
+
+          gh api --paginate \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/$GITHUB_REPOSITORY/actions/workflows/macos-arm64-wheels.yml/runs?event=pull_request&status=success&per_page=100" \
+            --jq '.workflow_runs[]' \
+            >"$RUNNER_TEMP/macos-runs.jsonl"
+          run_json="$(jq -cs --argjson pr "$RELEASE_PR" '
+            [.[]
+             | select(.event == "pull_request"
+                      and .status == "completed"
+                      and .conclusion == "success"
+                      and any(.pull_requests[]?; .number == $pr))]
+            | sort_by(.created_at, .id) | reverse | .[0] // empty
+          ' "$RUNNER_TEMP/macos-runs.jsonl")"
+          [[ -n "$run_json" ]] || {
+            echo "No successful macOS arm64 pull_request run found for PR $RELEASE_PR" >&2
+            exit 1
+          }
+          run_id="$(jq -er '.id' <<<"$run_json")"
+          run_url="$(jq -er '.html_url' <<<"$run_json")"
+
+          artifacts="$(gh api \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts?name=wheels-macos-arm64&per_page=100")"
+          artifact="$(jq -c '[.artifacts[] | select(.name == "wheels-macos-arm64")] |
+            if length == 1 then .[0] else error("expected exactly one wheels-macos-arm64 artifact") end' \
+            <<<"$artifacts")"
+          jq -e '.expired == false' <<<"$artifact" >/dev/null || {
+            echo "wheels-macos-arm64 artifact for run $run_id is expired" >&2
+            exit 1
+          }
+          artifact_id="$(jq -er '.id' <<<"$artifact")"
+          gh api \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
+            >"$RUNNER_TEMP/macos-arm64-wheels.zip"
+          unzip -t "$RUNNER_TEMP/macos-arm64-wheels.zip" >/dev/null
+          unzip -q "$RUNNER_TEMP/macos-arm64-wheels.zip" -d "$source_root"
+          {
+            echo "GHA_WHEEL_ROOT=$source_root"
+            echo "GHA_SOURCE_URL=$run_url"
+          } >>"$GITHUB_ENV"
+
+      - name: Download Azure wheel artifacts
+        env:
+          AZURE_DEVOPS_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+          RELEASE_PR: ${{ inputs.release_pr }}
+        run: |
+          set -Eeuo pipefail
+          source_root="$RUNNER_TEMP/release-sources/azure-drop"
+          rm -rf "$source_root"
+          mkdir -p "$source_root"
+          branch="refs/pull/$RELEASE_PR/merge"
+          builds_url="https://dev.azure.com/questdb/questdb/_apis/build/builds"
+          builds_json="$(curl --fail-with-body --silent --show-error \
+            --user ":$AZURE_DEVOPS_TOKEN" \
+            --get \
+            --data-urlencode 'definitions=21' \
+            --data-urlencode "branchName=$branch" \
+            --data-urlencode 'reasonFilter=pullRequest' \
+            --data-urlencode 'statusFilter=completed' \
+            --data-urlencode 'resultFilter=succeeded' \
+            --data-urlencode 'queryOrder=finishTimeDescending' \
+            --data-urlencode '$top=10' \
+            --data-urlencode 'api-version=7.1' \
+            "$builds_url")"
+          build="$(jq -c --arg branch "$branch" '
+            [.value[]
+             | select(.definition.id == 21
+                      and .sourceBranch == $branch
+                      and .reason == "pullRequest"
+                      and .status == "completed"
+                      and .result == "succeeded")]
+            | sort_by(.finishTime, .id) | reverse | .[0] // empty
+          ' <<<"$builds_json")"
+          [[ -n "$build" ]] || {
+            echo "No successful Azure definition 21 build found for $branch" >&2
+            exit 1
+          }
+          build_id="$(jq -er '.id' <<<"$build")"
+          build_url="https://dev.azure.com/questdb/questdb/_build/results?buildId=$build_id"
+          artifact_url="https://dev.azure.com/questdb/questdb/_apis/build/builds/$build_id/artifacts"
+          curl --fail-with-body --location --silent --show-error \
+            --user ":$AZURE_DEVOPS_TOKEN" \
+            -H 'Accept: application/zip' \
+            --get \
+            --data-urlencode 'artifactName=drop' \
+            --data-urlencode 'api-version=7.1' \
+            --output "$RUNNER_TEMP/azure-drop.zip" \
+            "$artifact_url"
+          unzip -t "$RUNNER_TEMP/azure-drop.zip" >/dev/null
+          unzip -q "$RUNNER_TEMP/azure-drop.zip" -d "$source_root"
+          {
+            echo "AZURE_WHEEL_ROOT=$source_root"
+            echo "AZURE_SOURCE_URL=$build_url"
+          } >>"$GITHUB_ENV"
+
+      - name: Build source distribution
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          rm -rf dist
+          mkdir dist
+          python -m pip install --disable-pip-version-check build packaging twine
+          python -m build --sdist --outdir dist
+
+      - name: Collect and validate distributions
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          python - <<'PY'
+          import os
+          import re
+          import shutil
+          import tarfile
+          from collections import Counter
+          from itertools import product
+          from pathlib import Path
+
+          from packaging.tags import Tag
+          from packaging.utils import (
+              canonicalize_name,
+              parse_sdist_filename,
+              parse_wheel_filename,
+          )
+          from packaging.version import Version
+
+          version = Version(os.environ["RELEASE_VERSION"])
+          dist = Path("dist")
+          roots = [Path(os.environ["GHA_WHEEL_ROOT"]), Path(os.environ["AZURE_WHEEL_ROOT"])]
+
+          source_files = []
+          for root in roots:
+              if not root.is_dir():
+                  raise SystemExit(f"wheel source directory does not exist: {root}")
+              files = sorted(path for path in root.rglob("*") if path.is_file())
+              unexpected = [path for path in files if path.suffix != ".whl"]
+              if unexpected:
+                  raise SystemExit(
+                      "non-wheel payload in wheel artifact: "
+                      + ", ".join(str(path) for path in unexpected)
+                  )
+              source_files.extend(files)
+
+          names = Counter(path.name for path in source_files)
+          duplicates = sorted(name for name, count in names.items() if count != 1)
+          if duplicates:
+              details = [
+                  f"{name}: {', '.join(str(path) for path in source_files if path.name == name)}"
+                  for name in duplicates
+              ]
+              raise SystemExit("duplicate wheel basename(s): " + "; ".join(details))
+          for path in source_files:
+              shutil.copy2(path, dist / path.name)
+
+          sdists = sorted(dist.glob("*.tar.gz"))
+          if len(sdists) != 1:
+              raise SystemExit(f"expected exactly one .tar.gz, found {[p.name for p in sdists]}")
+          sdist_name, sdist_version = parse_sdist_filename(sdists[0].name)
+          if canonicalize_name(sdist_name) != "questdb" or sdist_version != version:
+              raise SystemExit(f"unexpected sdist identity: {sdists[0].name}")
+
+          with tarfile.open(sdists[0], "r:gz") as archive:
+              members = archive.getmembers()
+              member_names = [member.name for member in members]
+              for name in member_names:
+                  path = Path(name)
+                  if path.is_absolute() or ".." in path.parts:
+                      raise SystemExit(f"unsafe sdist member path: {name}")
+              required_suffixes = (
+                  "/PKG-INFO",
+                  "/src/questdb/__init__.py",
+                  "/rpyutils/Cargo.toml",
+                  "/c-questdb-client/questdb-rs/Cargo.toml",
+                  "/c-questdb-client/questdb-rs-ffi/Cargo.toml",
+              )
+              for suffix in required_suffixes:
+                  if not any(name.endswith(suffix) for name in member_names):
+                      raise SystemExit(f"sdist missing required member ending in {suffix}")
+              print(
+                  f"sdist {sdists[0].name}: {len(members)} members, "
+                  f"{sdists[0].stat().st_size} bytes"
+              )
+
+          interpreters = ("cp310", "cp311", "cp312", "cp313", "cp314", "cp314t")
+          expected = set()
+          expected.update(product(interpreters, ("manylinux", "musllinux"), ("x86_64", "aarch64")))
+          expected.update(product(interpreters, ("macos",), ("x86_64", "arm64")))
+          expected.update(product(("cp310", "cp311", "cp312", "cp313", "cp314"), ("windows",), ("win32", "win_amd64")))
+
+          def classify_platform(platform):
+              linux = re.fullmatch(r"(manylinux[^.]*)_(x86_64|aarch64)", platform)
+              if linux:
+                  return "manylinux", linux.group(2), None
+              musl = re.fullmatch(r"(musllinux[^.]*)_(x86_64|aarch64)", platform)
+              if musl:
+                  return "musllinux", musl.group(2), None
+              mac = re.fullmatch(r"macosx_(\d+)_(\d+)_(x86_64|arm64|universal2)", platform)
+              if mac:
+                  return "macos", mac.group(3), (int(mac.group(1)), int(mac.group(2)))
+              if platform in ("win32", "win_amd64"):
+                  return "windows", platform, None
+              raise ValueError(f"unsupported platform tag {platform!r}")
+
+          def classify_tags(filename, tags):
+              targets = set()
+              for tag in tags:
+                  if tag.interpreter.startswith("cp"):
+                      if tag.interpreter not in {"cp310", "cp311", "cp312", "cp313", "cp314"}:
+                          raise ValueError(f"unsupported CPython interpreter tag {tag.interpreter!r}")
+                      if tag.interpreter == "cp314" and tag.abi == "cp314t":
+                          interpreter = "cp314t"
+                      elif tag.abi == tag.interpreter:
+                          interpreter = tag.interpreter
+                      else:
+                          raise ValueError(
+                              f"ABI {tag.abi!r} is inconsistent with {tag.interpreter!r}"
+                          )
+                  elif re.fullmatch(r"pp3\d+", tag.interpreter):
+                      if not tag.abi.startswith("pypy"):
+                          raise ValueError(f"invalid PyPy ABI {tag.abi!r}")
+                      interpreter = tag.interpreter
+                  else:
+                      raise ValueError(f"unsupported interpreter tag {tag.interpreter!r}")
+
+                  family, arch, mac_floor = classify_platform(tag.platform)
+                  if arch == "universal2":
+                      raise ValueError("macOS universal2 wheels are not release targets")
+                  if family == "macos" and arch == "arm64" and mac_floor < (11, 0):
+                      raise ValueError(f"macOS arm64 tag has deployment floor below 11.0: {tag.platform}")
+                  targets.add((interpreter, family, arch))
+              if len(targets) != 1:
+                  raise ValueError(f"tags span multiple semantic targets: {sorted(targets)}")
+              return targets.pop()
+
+          cpython = Counter()
+          pypy = Counter()
+          wheels = sorted(dist.glob("*.whl"))
+          for wheel in wheels:
+              try:
+                  name, wheel_version, _build, tags = parse_wheel_filename(wheel.name)
+                  if canonicalize_name(name) != "questdb" or wheel_version != version:
+                      raise ValueError(
+                          f"expected questdb {version}, got {canonicalize_name(name)} {wheel_version}"
+                      )
+                  target = classify_tags(wheel.name, tags)
+              except Exception as error:
+                  raise SystemExit(f"invalid wheel {wheel.name}: {error}") from error
+              if target[0].startswith("cp"):
+                  cpython[target] += 1
+              else:
+                  if target[1:] != ("manylinux", "x86_64"):
+                      raise SystemExit(f"unexpected PyPy wheel target {target}: {wheel.name}")
+                  pypy[target] += 1
+
+          missing = sorted(expected - set(cpython))
+          extra = sorted(set(cpython) - expected)
+          repeated = sorted(target for target, count in cpython.items() if count != 1)
+          if missing or extra or repeated:
+              raise SystemExit(
+                  f"CPython wheel matrix mismatch; missing={missing}, extra={extra}, repeated={repeated}"
+              )
+          if not pypy:
+              raise SystemExit("missing PyPy 3 manylinux x86_64 wheel")
+          repeated_pypy = sorted(target for target, count in pypy.items() if count != 1)
+          if repeated_pypy:
+              raise SystemExit(f"duplicate PyPy wheel target(s): {repeated_pypy}")
+
+          distributions = sorted(path.name for path in dist.iterdir() if path.is_file())
+          if len(distributions) != len(wheels) + 1:
+              raise SystemExit(f"unexpected distribution payload: {distributions}")
+          print(f"validated {len(wheels)} wheels and one source distribution")
+          PY
+
+      - name: Check distribution metadata
+        run: |
+          set -Eeuo pipefail
+          python -m twine check dist/*
+
+      - name: Generate release notes
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"]
+          lines = Path("CHANGELOG.rst").read_text().splitlines()
+          heading_re = re.compile(r"^(\d+\.\d+\.\d+(?:[a-zA-Z0-9.-]+)?) \([^)]+\)$")
+          start = next((i for i, line in enumerate(lines)
+                        if line.startswith(version + " (") and heading_re.fullmatch(line)), None)
+          if start is None:
+              raise SystemExit(f"no changelog section for {version}")
+          end = next((i for i in range(start + 2, len(lines)) if heading_re.fullmatch(lines[i])), len(lines))
+          section = lines[start:end]
+
+          converted = []
+          index = 0
+          while index < len(section):
+              line = section[index]
+              if index + 1 < len(section) and re.fullmatch(r"[-~^=]+", section[index + 1]):
+                  level = "#" if section[index + 1][0] in "=-" else "##"
+                  converted.append(f"{level} {line}")
+                  index += 2
+                  continue
+              line = re.sub(r"``([^`]+)``", r"`\1`", line)
+              line = re.sub(r":[A-Za-z0-9_-]+:`([^`<]+?)\s*<[^`>]+>`", r"\1", line)
+              line = re.sub(r":[A-Za-z0-9_-]+:`([^`]+)`", r"\1", line)
+              converted.append(line)
+              index += 1
+          Path("release-notes.md").write_text("\n".join(converted).rstrip() + "\n")
+          PY
+
+      - name: Write preparation summary
+        env:
+          RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
+        run: |
+          set -Eeuo pipefail
+          {
+            echo "## Validated release bundle"
+            echo
+            echo "- Release commit: \`$RELEASE_SHA\`"
+            echo "- macOS arm64 source run: $GHA_SOURCE_URL"
+            echo "- Azure source build: $AZURE_SOURCE_URL"
+            echo "- Package count: $(find dist -maxdepth 1 -type f | wc -l)"
+            echo
+            echo "### Packages"
+            find dist -maxdepth 1 -type f -printf '%f\n' | LC_ALL=C sort | sed 's/^/- `/' | sed 's/$/`/'
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-bundle
+          path: |
+            dist/*
+            release-notes.md
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -484,3 +484,322 @@ jobs:
             release-notes.md
           retention-days: 7
           if-no-files-found: error
+
+  publish:
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    steps:
+      - name: Check out the release commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Download release bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: release-bundle
+
+      - name: Check immutable tag and initialize publication URLs
+        env:
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || {
+            echo "Checked-out commit does not match release commit $RELEASE_SHA" >&2
+            exit 1
+          }
+          git fetch --tags origin
+          if git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"; then
+            tag_sha="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
+            [[ "$tag_sha" == "$RELEASE_SHA" ]] || {
+              echo "Existing tag $RELEASE_TAG resolves to $tag_sha, expected $RELEASE_SHA" >&2
+              exit 1
+            }
+            echo "RELEASE_TAG_EXISTS=true" >>"$GITHUB_ENV"
+          else
+            echo "RELEASE_TAG_EXISTS=false" >>"$GITHUB_ENV"
+          fi
+          {
+            echo "PYPI_RELEASE_URL=https://pypi.org/project/questdb/$RELEASE_VERSION/"
+            echo "GITHUB_RELEASE_URL=https://github.com/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG"
+            echo "READTHEDOCS_BUILD_URL=https://app.readthedocs.org/projects/py-questdb-client/builds/"
+          } >>"$GITHUB_ENV"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+
+      - name: Create immutable release tag when absent
+        env:
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -Eeuo pipefail
+          if [[ "$RELEASE_TAG_EXISTS" == false ]]; then
+            git tag "$RELEASE_TAG" "$RELEASE_SHA"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
+
+      - name: Create or recover GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          title="QuestDB Python client $RELEASE_VERSION"
+          api_url="https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG"
+          release_json="$RUNNER_TEMP/github-release.json"
+
+          gh api \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/$GITHUB_REPOSITORY" >/dev/null
+
+          lookup_release() {
+            local status
+            status="$(curl --silent --show-error \
+              --output "$release_json" \
+              --write-out '%{http_code}' \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "$api_url")" || {
+                echo "GitHub release lookup failed before receiving an HTTP response" >&2
+                return 1
+              }
+            case "$status" in
+              200) return 0 ;;
+              404) return 4 ;;
+              *)
+                echo "GitHub release lookup failed with HTTP $status" >&2
+                jq -r '.message // empty' "$release_json" >&2 || true
+                return 1
+                ;;
+            esac
+          }
+
+          verify_assets() {
+            local expected_json asset name count asset_id downloaded
+            expected_json="$(printf '%s\n' "${expected_assets[@]##*/}" | jq -R . | jq -s .)"
+            jq -e --argjson expected "$expected_json" '
+              ([.assets[].name] | length) == ([.assets[].name] | unique | length)
+              and (([.assets[].name] | sort) == ($expected | sort))
+            ' "$release_json" >/dev/null || {
+              echo "GitHub release asset names do not exactly match the release bundle" >&2
+              return 1
+            }
+            for asset in "${expected_assets[@]}"; do
+              name="${asset##*/}"
+              count="$(jq --arg name "$name" '[.assets[] | select(.name == $name)] | length' "$release_json")"
+              [[ "$count" == 1 ]] || {
+                echo "Expected exactly one GitHub release asset named $name" >&2
+                return 1
+              }
+              asset_id="$(jq -er --arg name "$name" '.assets[] | select(.name == $name) | .id' "$release_json")"
+              downloaded="$RUNNER_TEMP/github-asset-$asset_id"
+              gh api \
+                -H 'Accept: application/octet-stream' \
+                "/repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" >"$downloaded"
+              cmp --silent "$asset" "$downloaded" || {
+                echo "Existing GitHub release asset $name differs from the validated bundle" >&2
+                return 1
+              }
+            done
+          }
+
+          mapfile -d '' expected_assets < <(find dist -maxdepth 1 -type f -print0 | LC_ALL=C sort -z)
+          (( ${#expected_assets[@]} > 0 )) || {
+            echo "Release bundle contains no distributions" >&2
+            exit 1
+          }
+
+          if lookup_release; then
+            release_exists=true
+          else
+            lookup_status=$?
+            if [[ "$lookup_status" == 4 ]]; then
+              release_exists=false
+            else
+              exit "$lookup_status"
+            fi
+          fi
+
+          if [[ "$release_exists" == false ]]; then
+            gh release create "$RELEASE_TAG" \
+              --verify-tag \
+              --draft \
+              --title "$title" \
+              --notes-file release-notes.md
+            lookup_release
+          fi
+
+          jq -e --arg tag "$RELEASE_TAG" '
+            .tag_name == $tag and .prerelease == false
+          ' "$release_json" >/dev/null || {
+            echo "Existing GitHub release has unexpected tag or prerelease state" >&2
+            exit 1
+          }
+
+          is_draft="$(jq -r '.draft | if type == "boolean" then tostring else error("draft is not boolean") end' "$release_json")"
+          if [[ "$is_draft" == false ]]; then
+            jq -e --arg title "$title" --rawfile notes release-notes.md '
+              .name == $title and .body == $notes
+            ' "$release_json" >/dev/null || {
+              echo "Published GitHub release metadata differs from the validated bundle" >&2
+              exit 1
+            }
+            verify_assets
+            exit 0
+          fi
+
+          jq -e '.immutable != true' "$release_json" >/dev/null || {
+            echo "Draft GitHub release is immutable and cannot be recovered" >&2
+            exit 1
+          }
+          gh release edit "$RELEASE_TAG" \
+            --draft=true \
+            --prerelease=false \
+            --title "$title" \
+            --notes-file release-notes.md
+          lookup_release
+
+          for asset in "${expected_assets[@]}"; do
+            name="${asset##*/}"
+            count="$(jq --arg name "$name" '[.assets[] | select(.name == $name)] | length' "$release_json")"
+            case "$count" in
+              0) gh release upload "$RELEASE_TAG" "$asset" ;;
+              1)
+                asset_id="$(jq -er --arg name "$name" '.assets[] | select(.name == $name) | .id' "$release_json")"
+                downloaded="$RUNNER_TEMP/github-asset-$asset_id"
+                gh api \
+                  -H 'Accept: application/octet-stream' \
+                  "/repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" >"$downloaded"
+                cmp --silent "$asset" "$downloaded" || {
+                  echo "Existing GitHub release asset $name differs from the validated bundle" >&2
+                  exit 1
+                }
+                ;;
+              *)
+                echo "GitHub release has duplicate assets named $name" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          lookup_release
+          verify_assets
+          gh release edit "$RELEASE_TAG" \
+            --draft=false \
+            --prerelease=false \
+            --title "$title" \
+            --notes-file release-notes.md
+          lookup_release
+          jq -e --arg title "$title" --rawfile notes release-notes.md '
+            .draft == false and .prerelease == false and .name == $title and .body == $notes
+          ' "$release_json" >/dev/null || {
+            echo "Published GitHub release metadata could not be verified" >&2
+            exit 1
+          }
+          verify_assets
+
+      - name: Trigger and monitor Read the Docs
+        env:
+          READTHEDOCS_TOKEN: ${{ secrets.READTHEDOCS_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          api_root="https://app.readthedocs.org/api/v3/projects/py-questdb-client"
+          deadline=$((SECONDS + 1800))
+          trigger_json="$(curl --fail-with-body --silent --show-error \
+            --max-time 30 \
+            --request POST \
+            -H "Authorization: Token $READTHEDOCS_TOKEN" \
+            -H 'Accept: application/json' \
+            "$api_root/versions/latest/builds/")"
+          build_id="$(jq -er '
+            .build.id
+            | if type == "number" then select(floor == .) | tostring
+              elif type == "string" then select(test("^[0-9]+$"))
+              else empty
+              end
+          ' <<<"$trigger_json")" || {
+            echo "Read the Docs trigger response has no valid build ID" >&2
+            exit 1
+          }
+          echo "READTHEDOCS_BUILD_URL=https://app.readthedocs.org/projects/py-questdb-client/builds/$build_id/" \
+            >>"$GITHUB_ENV"
+
+          while (( SECONDS < deadline )); do
+            remaining=$((deadline - SECONDS))
+            (( remaining > 0 )) || break
+            build_json="$(curl --fail-with-body --silent --show-error \
+              --max-time "$remaining" \
+              -H "Authorization: Token $READTHEDOCS_TOKEN" \
+              -H 'Accept: application/json' \
+              "$api_root/builds/$build_id/")"
+            returned_id="$(jq -er '.id | tostring' <<<"$build_json")"
+            [[ "$returned_id" == "$build_id" ]] || {
+              echo "Read the Docs returned build $returned_id while polling $build_id" >&2
+              exit 1
+            }
+            state="$(jq -er '
+              if (.state | type) == "object" then .state.code
+              elif (.state | type) == "string" then .state
+              else empty
+              end
+              | select(type == "string" and length > 0)
+            ' <<<"$build_json")"
+            case "$state" in
+              finished)
+                jq -e '.success == true' <<<"$build_json" >/dev/null || {
+                  echo "Read the Docs build $build_id finished unsuccessfully" >&2
+                  jq '{id, version, state, success, error, commit}' <<<"$build_json" >&2
+                  exit 1
+                }
+                exit 0
+                ;;
+              cancelled)
+                echo "Read the Docs build $build_id was cancelled" >&2
+                jq '{id, version, state, success, error, commit}' <<<"$build_json" >&2
+                exit 1
+                ;;
+              triggered|building|installing|cloning)
+                remaining=$((deadline - SECONDS))
+                (( remaining > 0 )) || break
+                (( remaining < 15 )) && sleep "$remaining" || sleep 15
+                ;;
+              *)
+                echo "Unknown Read the Docs build state: $state" >&2
+                exit 1
+                ;;
+            esac
+          done
+          echo "Read the Docs build $build_id did not finish within 30 minutes" >&2
+          exit 1
+
+      - name: Write publication summary
+        if: ${{ always() }}
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          pypi_url="${PYPI_RELEASE_URL:-https://pypi.org/project/questdb/$RELEASE_VERSION/}"
+          release_url="${GITHUB_RELEASE_URL:-https://github.com/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG}"
+          docs_url="${READTHEDOCS_BUILD_URL:-https://app.readthedocs.org/projects/py-questdb-client/builds/}"
+          {
+            echo "## Release publication"
+            echo
+            echo "- PyPI: $pypi_url"
+            echo "- GitHub release: $release_url"
+            echo "- Read the Docs build: $docs_url"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Check out the release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ steps.release.outputs.release_sha }}
           fetch-depth: 0
@@ -150,13 +150,13 @@ jobs:
             "/repos/$GITHUB_REPOSITORY/actions/workflows/macos-arm64-wheels.yml/runs?event=pull_request&status=success&per_page=100" \
             --jq '.workflow_runs[]' \
             >"$RUNNER_TEMP/macos-runs.jsonl"
-          run_json="$(jq -cs --argjson pr "$RELEASE_PR" --arg head "$PR_HEAD_SHA" '
+          run_json="$(jq -cs --arg head "$PR_HEAD_SHA" '
             [.[]
-             | select(.event == "pull_request"
+             | select(.path == ".github/workflows/macos-arm64-wheels.yml"
+                      and .event == "pull_request"
                       and .status == "completed"
                       and .conclusion == "success"
-                      and .head_sha == $head
-                      and any(.pull_requests[]?; .number == $pr))]
+                      and .head_sha == $head)]
             | sort_by(.created_at, .id) | reverse | .[0] // empty
           ' "$RUNNER_TEMP/macos-runs.jsonl")"
           [[ -n "$run_json" ]] || {
@@ -277,7 +277,6 @@ jobs:
           from itertools import product
           from pathlib import Path
 
-          from packaging.tags import Tag
           from packaging.utils import (
               canonicalize_name,
               parse_sdist_filename,
@@ -342,6 +341,8 @@ jobs:
                   f"{sdists[0].stat().st_size} bytes"
               )
 
+          # This explicit 46-target CPython matrix duplicates ci/cibuildwheel.yaml and
+          # .github/workflows/macos-arm64-wheels.yml; update it whenever either CI matrix changes.
           interpreters = ("cp310", "cp311", "cp312", "cp313", "cp314", "cp314t")
           expected = set()
           expected.update(product(interpreters, ("manylinux", "musllinux"), ("x86_64", "aarch64")))
@@ -362,7 +363,7 @@ jobs:
                   return "windows", platform, None
               raise ValueError(f"unsupported platform tag {platform!r}")
 
-          def classify_tags(filename, tags):
+          def classify_tags(tags):
               targets = set()
               for tag in tags:
                   if tag.interpreter.startswith("cp"):
@@ -403,7 +404,7 @@ jobs:
                       raise ValueError(
                           f"expected questdb {version}, got {canonicalize_name(name)} {wheel_version}"
                       )
-                  target = classify_tags(wheel.name, tags)
+                  target = classify_tags(tags)
               except Exception as error:
                   raise SystemExit(f"invalid wheel {wheel.name}: {error}") from error
               if target[0].startswith("cp"):
@@ -436,6 +437,64 @@ jobs:
         run: |
           set -Eeuo pipefail
           python -m twine check dist/*
+
+      - name: Verify any pre-existing PyPI files
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"]
+          local = {
+              path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+              for path in Path("dist").iterdir()
+              if path.is_file()
+          }
+          if not local:
+              raise SystemExit("release bundle contains no distributions")
+
+          request = urllib.request.Request(
+              f"https://pypi.org/pypi/questdb/{version}/json",
+              headers={"Accept": "application/json"},
+          )
+          try:
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  if response.status != 200:
+                      raise SystemExit(f"PyPI lookup returned unexpected HTTP {response.status}")
+                  payload = json.load(response)
+          except urllib.error.HTTPError as error:
+              if error.code == 404:
+                  print(f"PyPI has no pre-existing files for questdb {version}")
+                  raise SystemExit(0)
+              raise SystemExit(f"PyPI lookup failed with HTTP {error.code}") from error
+          except (OSError, json.JSONDecodeError) as error:
+              raise SystemExit(f"PyPI lookup failed: {error}") from error
+
+          urls = payload.get("urls")
+          if not isinstance(urls, list):
+              raise SystemExit("PyPI response has no file list")
+          seen = set()
+          for entry in urls:
+              name = entry.get("filename") if isinstance(entry, dict) else None
+              digest = entry.get("digests", {}).get("sha256") if isinstance(entry, dict) else None
+              if not isinstance(name, str) or not isinstance(digest, str):
+                  raise SystemExit("PyPI response contains invalid file metadata")
+              if name in seen:
+                  raise SystemExit(f"PyPI response contains duplicate filename {name}")
+              seen.add(name)
+              if name not in local:
+                  raise SystemExit(f"PyPI contains unexpected file for this version: {name}")
+              if digest.lower() != local[name]:
+                  raise SystemExit(f"PyPI SHA-256 mismatch for pre-existing file {name}")
+          print(f"verified {len(seen)} pre-existing PyPI file(s) against the release bundle")
+          PY
 
       - name: Generate release notes
         env:
@@ -492,7 +551,7 @@ jobs:
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload release bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-bundle
           path: |
@@ -511,13 +570,13 @@ jobs:
       id-token: write
     steps:
       - name: Check out the release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.prepare.outputs.release_sha }}
           fetch-depth: 0
 
       - name: Download release bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-bundle
 
@@ -550,10 +609,87 @@ jobs:
           } >>"$GITHUB_ENV"
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: dist/
           skip-existing: true
+
+      - name: Verify complete PyPI publication
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -Eeuo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"]
+          expected = {
+              path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+              for path in Path("dist").iterdir()
+              if path.is_file()
+          }
+          if not expected:
+              raise SystemExit("release bundle contains no distributions")
+          url = f"https://pypi.org/pypi/questdb/{version}/json"
+          deadline = time.monotonic() + 600
+
+          while True:
+              try:
+                  request = urllib.request.Request(url, headers={"Accept": "application/json"})
+                  with urllib.request.urlopen(request, timeout=30) as response:
+                      if response.status != 200:
+                          raise SystemExit(
+                              f"PyPI verification returned unexpected HTTP {response.status}"
+                          )
+                      payload = json.load(response)
+              except urllib.error.HTTPError as error:
+                  if error.code != 404:
+                      raise SystemExit(
+                          f"PyPI verification failed with HTTP {error.code}"
+                      ) from error
+                  payload = {"urls": []}
+              except (OSError, json.JSONDecodeError) as error:
+                  raise SystemExit(f"PyPI verification failed: {error}") from error
+
+              urls = payload.get("urls")
+              if not isinstance(urls, list):
+                  raise SystemExit("PyPI response has no file list")
+              actual = {}
+              for entry in urls:
+                  name = entry.get("filename") if isinstance(entry, dict) else None
+                  digest = entry.get("digests", {}).get("sha256") if isinstance(entry, dict) else None
+                  if not isinstance(name, str) or not isinstance(digest, str):
+                      raise SystemExit("PyPI response contains invalid file metadata")
+                  if name in actual:
+                      raise SystemExit(f"PyPI response contains duplicate filename {name}")
+                  actual[name] = digest.lower()
+
+              extra = sorted(set(actual) - set(expected))
+              mismatched = sorted(
+                  name for name in set(actual) & set(expected)
+                  if actual[name] != expected[name]
+              )
+              if extra or mismatched:
+                  raise SystemExit(
+                      f"PyPI publication mismatch; extra={extra}, hash_mismatch={mismatched}"
+                  )
+              missing = sorted(set(expected) - set(actual))
+              if not missing:
+                  print(f"verified all {len(expected)} PyPI files by SHA-256")
+                  break
+              if time.monotonic() >= deadline:
+                  raise SystemExit(
+                      f"PyPI did not expose the complete release within 10 minutes; missing={missing}"
+                  )
+              print(f"waiting for PyPI propagation; missing={missing}", flush=True)
+              time.sleep(15)
+          PY
 
       - name: Create immutable release tag when absent
         env:
@@ -762,9 +898,18 @@ jobs:
               -H "Authorization: Token $READTHEDOCS_TOKEN" \
               -H 'Accept: application/json' \
               "$api_root/builds/$build_id/")"
-            returned_id="$(jq -er '.id | tostring' <<<"$build_json")"
-            [[ "$returned_id" == "$build_id" ]] || {
-              echo "Read the Docs returned build $returned_id while polling $build_id" >&2
+            jq -e --arg id "$build_id" '
+              def slug:
+                if type == "string" then .
+                elif type == "object" then .slug
+                else null
+                end;
+              (.id | tostring) == $id
+              and (.project | slug) == "py-questdb-client"
+              and (.version | slug) == "latest"
+            ' <<<"$build_json" >/dev/null || {
+              echo "Read the Docs returned the wrong build, project, or version while polling $build_id" >&2
+              jq '{id, project, version}' <<<"$build_json" >&2
               exit 1
             }
             state="$(jq -er '
@@ -788,7 +933,7 @@ jobs:
                 jq '{id, version, state, success, error, commit}' <<<"$build_json" >&2
                 exit 1
                 ;;
-              triggered|building|installing|cloning)
+              triggered|building|installing|cloning|uploading)
                 remaining=$((deadline - SECONDS))
                 (( remaining > 0 )) || break
                 (( remaining < 15 )) && sleep "$remaining" || sleep 15

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -29,166 +29,76 @@ matching the 2.x releases: ``tls_verify=unsafe_off`` works out of the
 box, and TLS verification stays on unless the user explicitly disables
 it in the conf string.
 
-The source distribution is built on your workstation, which is also
-where you collate the CI artifacts and perform the final upload to PyPI.
+The release workflow collects the CI wheels, builds the source
+distribution, validates the complete bundle, and publishes it.
 
-Bumping Version and updating Changelog
---------------------------------------
+One-time administrator setup
+----------------------------
 
-Create a new PR with the new changes in ``CHANGELOG.rst``.
+This setup is required before the first live release workflow run. It is
+not required to review or merge the workflow code.
 
-Make a commit and push the changes to a new branch.
+1. In the GitHub repository, create an environment named ``pypi`` and
+   configure required reviewers.
+2. On PyPI, add a Trusted Publisher for:
 
-You also want to bump the version. This process is semi-automated.
+   * repository: ``questdb/py-questdb-client``
+   * workflow: ``release.yml``
+   * environment: ``pypi``
 
-Ensure you have ``uv`` and ``bump-my-version`` installed:
+3. In the GitHub repository, add repository secret
+   ``AZURE_DEVOPS_TOKEN`` with its Azure DevOps token scoped to Build Read.
+4. In the GitHub ``pypi`` environment, add environment secret
+   ``READTHEDOCS_TOKEN``.
 
-* ``curl -LsSf https://astral.sh/uv/install.sh | sh`` : see
-  https://docs.astral.sh/uv/getting-started/installation/
-* ``uv tool install bump-my-version``: see
-  https://github.com/callowayproject/bump-my-version.
+Prepare the release PR
+----------------------
 
-::
+1. Update ``CHANGELOG.rst`` with the release notes.
+2. Set the version with ``bump-my-version``::
 
-    bump-my-version replace --new-version NEW_VERSION
+       bump-my-version replace --new-version X.Y.Z
 
-If you're unsure, append ``--dry-run`` to preview changes.
+   Add ``--dry-run`` to preview the changes.
+3. Set the changelog date to the intended UTC release date. The workflow
+   requires that date to match the UTC date on which it runs.
+4. Open the version/changelog PR. Merge it only after both the Azure
+   wheel checks and the **macOS arm64 wheels** check pass.
+5. Keep the merged PR number for the ``release_pr`` workflow input.
 
-Now merge the PR with the title "Bump version: V.V.V → W.W.W".
+Run the release
+---------------
 
-Note that CI builds the release binaries on the bump PR itself — both
-systems run as PR checks:
+1. In GitHub, open **Actions** → **Release** → **Run workflow**.
+2. Select branch ``main``.
+3. Enter ``version`` without the ``v`` prefix, for example ``X.Y.Z``.
+4. Enter the merged PR number in ``release_pr``, then select
+   **Run workflow**.
+5. Open the ``prepare`` job and inspect its **Validated release bundle**
+   summary, including the release commit, source runs, package count,
+   and package list.
+6. At the protected ``pypi`` environment gate, approve the ``publish``
+   job. This publishes to PyPI using Trusted Publishing, creates tag
+   ``vX.Y.Z`` and the GitHub release, and triggers Read the Docs.
 
-* Azure Pipelines runs the ``cibuildwheel`` jobs for Linux, Windows and
-  macOS Intel.
-* The GitHub Actions "macOS arm64 wheels" workflow builds the macOS ARM
-  wheels. (It can also be triggered manually: Actions tab → "macOS arm64
-  wheels" → "Run workflow", or ``gh workflow run "macOS arm64 wheels"``.)
+Verify
+------
 
-The binaries you release are collected from the merged bump PR's runs.
+1. Open the ``publish`` job's **Release publication** summary.
+2. Follow and check all three links:
 
-Double-check the date in the CHANGELOG
---------------------------------------
+   * **PyPI**: the new version and files are present.
+   * **GitHub release**: the release notes and distribution assets are
+     present under ``vX.Y.Z``.
+   * **Read the Docs build**: the build finished successfully.
 
-Open ``CHANGELOG.rst`` and ensure that the version you are releasing no
-longer says "(unreleased)" and that the date next to it matches today's
-date. If the CHANGELOG was created earlier, it might have an older date.
-If so, update it.
+Recover
+-------
 
-Prepare the source distribution
--------------------------------
-
-The source code distribution is for any other platforms that we don't have
-binaries for. I don't think it's _actually_ used by anyone, but it might get
-used by IDEs.
-
-From an up-to-date clone (with submodules initialized) on the release
-commit::
-
-    cd ~/questdb/py-questdb-client
-    git checkout main
-    git pull
-    git submodule update --init --recursive
-    python3 setup.py sdist
-
-Download the macOS ARM binaries from GitHub Actions
----------------------------------------------------
-
-Find the workflow run for the bump PR and download its artifact into
-``dist/``::
-
-    gh run list --workflow "macOS arm64 wheels" --limit 5
-    gh run download <run-id> --name wheels-macos-arm64 --dir dist
-
-(Or via the browser: the bump PR's Checks tab → "macOS arm64 wheels" —
-or Actions tab → "macOS arm64 wheels" → the run for the bump PR — then
-download the ``wheels-macos-arm64`` artifact.)
-
-Download the other binaries from Azure CI
------------------------------------------
-
-From a terminal, run::
-
-    cd ~/Downloads
-    rm drop.zip
-    rm -rf drop
-
-Launch a browser, log into GitHub and open the last (closed and merged) PR.
-
-Click on the "Checks" tab and open up the last "questdb.py-questdb-client (1)"
-check. There will be a link to the Azure DevOps page.
-
-The following link might also work: https://dev.azure.com/questdb/questdb/_build?definitionId=21&_a=summary
-
-If you open up the last run, you'll find a link called "1 published".
-This will redirect you to the "Published artifacts" page.
-
-There will be a "drop" directory.
-* Don't open it.
-* Instead use click on the three vertical dots on the right-hand
-side and select download artifacts.
-
-This will download a file called "drop.zip".
-
-double-check it in Finder: It will extract to a directory called "drop".
-
-Now from the terminal, run::
-
-    cd ~/questdb/py-questdb-client
-    cp -vr ~/Downloads/drop/* dist/
-
-Sanity-check the contents of ``dist/`` before uploading. You should see:
-
-* ``manylinux`` and ``musllinux`` wheels for both ``x86_64`` and
-  ``aarch64``, CPython 3.10 through 3.14 plus ``cp314t``;
-* PyPy (``pp3*``) wheels for Linux x86_64;
-* ``win32`` and ``win_amd64`` wheels, CPython 3.10 through 3.14
-  (no ``cp314t``);
-* ``macosx`` wheels for both ``x86_64`` (from Azure) and ``arm64``
-  (from GitHub Actions), CPython 3.10 through 3.14 plus ``cp314t``;
-* exactly one ``.tar.gz`` source distribution.
-
-Tagging the release
--------------------
-
-In GitHub with a web browser create a new release with the tag "vX.Y.Z"
-(where X.Y.Z is the new version number).
-
-The release notes should be copied from the ``CHANGELOG.rst`` file,
-but reformatted as Markdown.
-
-
-Uploading to PyPI
------------------
-
-``dist/`` now holds all the binaries and the source distribution, ready
-to be uploaded to PyPI.
-
-This is a good time to double-check you can log into PyPI and have set up an
-API token. If you don't have one (or lost it), you can create a new one here:
-https://pypi.org/manage/account/ (scroll down to "API tokens").
-
-Once you've triple-checked everything is in ``dist/``, you can upload to PyPI.
-
-.. code-block:: bash
-
-    python3 -m pip install -U twine
-    python3 -m twine upload dist/*
-
-This will prompt you for your PyPI username and token.
-
-Once the upload is complete, you can check the PyPI page to see if the new
-release is there: https://pypi.org/project/questdb/
-
-
-Updating the docs
------------------
-
-Log into ReadTheDocs and trigger a new build for the project.
-
-https://readthedocs.org/dashboard/py-questdb-client/users/
-
-Watch it to ensure there are no errors.
-
-Once the build is complete, COMMAND-SHIFT-R to refresh the page (without cache)
-and check the new version is there.
+1. Fix a transient dependency or configuration failure, then rerun the
+   failed job with the same ``version`` and ``release_pr`` inputs. The
+   publish steps recover completed work and do not replace matching
+   artifacts.
+2. Never move an existing release tag. If ``vX.Y.Z`` points to a commit
+   other than the validated release commit, stop and investigate the
+   tag-to-commit mismatch before retrying.

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -38,8 +38,9 @@ One-time administrator setup
 This setup is required before the first live release workflow run. It is
 not required to review or merge the workflow code.
 
-1. In the GitHub repository, create an environment named ``pypi`` and
-   configure required reviewers.
+1. In the GitHub repository, create an environment named ``pypi``. Allow
+   deployments only from ``main``, configure required reviewers, and prevent
+   initiators from approving their own runs where the repository plan supports it.
 2. On PyPI, add a Trusted Publisher for:
 
    * repository: ``questdb/py-questdb-client``
@@ -47,9 +48,11 @@ not required to review or merge the workflow code.
    * environment: ``pypi``
 
 3. In the GitHub repository, add repository secret
-   ``AZURE_DEVOPS_TOKEN`` with its Azure DevOps token scoped to Build Read.
+   ``AZURE_DEVOPS_TOKEN`` with an Azure PAT scoped only to Build Read. Assign a
+   named owner responsible for its expiry and rotation.
 4. In the GitHub ``pypi`` environment, add environment secret
-   ``READTHEDOCS_TOKEN``.
+   ``READTHEDOCS_TOKEN``, using a token limited to the
+   ``py-questdb-client`` project.
 
 Prepare the release PR
 ----------------------
@@ -96,9 +99,10 @@ Recover
 -------
 
 1. Fix a transient dependency or configuration failure, then rerun the
-   failed job with the same ``version`` and ``release_pr`` inputs. The
-   publish steps recover completed work and do not replace matching
-   artifacts.
+   failed job with the same ``version`` and ``release_pr`` inputs. Before
+   continuation, the workflow automatically verifies every pre-existing PyPI
+   filename and SHA-256 hash against the validated bundle. The publish steps
+   recover completed work and do not replace matching artifacts.
 2. Never move an existing release tag. If ``vX.Y.Z`` points to a commit
    other than the validated release commit, stop and investigate the
    tag-to-commit mismatch before retrying.

--- a/docs/superpowers/plans/2026-08-12-automated-release-workflow.md
+++ b/docs/superpowers/plans/2026-08-12-automated-release-workflow.md
@@ -1,0 +1,311 @@
+# Automated Release Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one manually dispatched GitHub Actions workflow that assembles the release-PR artifacts, validates them, pauses for approval, publishes to PyPI, creates the GitHub release, and verifies ReadTheDocs.
+
+**Architecture:** `.github/workflows/release.yml` owns orchestration and keeps all release-specific shell/Python inline. A read-only `prepare` job validates the merged PR and packages and uploads one internal artifact; a protected `publish` job consumes exactly that artifact and performs external changes. `RELEASING.rst` becomes the short operator runbook.
+
+**Tech Stack:** GitHub Actions, GitHub CLI/API, Azure DevOps REST API 7.1, inline Python 3, `build`, `packaging`, `twine`, PyPI Trusted Publishing, ReadTheDocs API v3.
+
+## Global Constraints
+
+- Keep Azure and GitHub wheel builders unchanged.
+- Add no repository-owned release program or third-party release service.
+- Start only through `workflow_dispatch` on `main`, with required `version` and `release_pr` inputs.
+- Reuse wheel artifacts from the merged release PR; do not rebuild wheels.
+- Require protected GitHub environment `pypi` before any publishing side effect.
+- Use PyPI Trusted Publishing and a read-only Azure build-artifact token.
+- Trigger and monitor the ReadTheDocs `latest` build.
+- Make reruns safe without deleting or moving an existing tag.
+
+---
+
+### Task 1: Build and validate the release bundle
+
+**Files:**
+- Create: `.github/workflows/release.yml`
+
+**Interfaces:**
+- Consumes: dispatch inputs `version: string`, `release_pr: string`; secret `AZURE_DEVOPS_TOKEN`.
+- Produces: job outputs `version: string`, `tag: string`, `release_sha: 40-character commit SHA`; Actions artifact `release-bundle` containing `dist/*` and `release-notes.md`.
+
+- [ ] **Step 1: Write a failing structural check**
+
+Run this before the workflow exists:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+p = Path('.github/workflows/release.yml')
+assert p.exists()
+s = p.read_text()
+for required in ('workflow_dispatch:', 'version:', 'release_pr:', 'prepare:',
+                 'AZURE_DEVOPS_TOKEN', 'release-bundle'):
+    assert required in s, required
+PY
+```
+
+Expected: FAIL because `.github/workflows/release.yml` does not exist.
+
+- [ ] **Step 2: Add the trigger and read-only prepare-job shell**
+
+Create the workflow with:
+
+```yaml
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version without the v prefix (for example, 5.0.1)
+        required: true
+        type: string
+      release_pr:
+        description: Merged version/changelog PR number
+        required: true
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
+      release_sha: ${{ steps.release.outputs.release_sha }}
+```
+
+The prepare steps must do the following, with `set -Eeuo pipefail` on every shell block:
+
+1. Reject a dispatch whose `github.ref` is not `refs/heads/main`.
+2. Validate `version` against `^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.-]+)?$` and `release_pr` against `^[0-9]+$`.
+3. Use `gh api repos/$GITHUB_REPOSITORY/pulls/<PR>` to require `merged == true`, `base.ref == main`, and `head.repo.full_name == $GITHUB_REPOSITORY`; emit the merge commit SHA, version, and `v<version>` through `$GITHUB_OUTPUT`.
+4. Check out that merge SHA using `actions/checkout@v4`, `fetch-depth: 0`, and recursive submodules, then require `git merge-base --is-ancestor HEAD origin/main`.
+5. In inline Python, load `.bumpversion.toml` with `tomllib`, confirm `current_version`, evaluate each configured literal `search` after replacing `{current_version}`, and require it in the target file. Parse the first matching `CHANGELOG.rst` heading and require `<version> (<UTC YYYY-MM-DD>)`, rejecting `unreleased`.
+6. Query `.github/workflows/macos-arm64-wheels.yml` runs with `gh api`, selecting exactly the newest successful `pull_request` run whose `pull_requests[].number` matches the input. Download only its non-expired `wheels-macos-arm64` artifact.
+7. Query Azure build API 7.1 with definition `21`, branch `refs/pull/<PR>/merge`, reason `pullRequest`, completed/succeeded filters, newest-first ordering, and top 10. Select the newest build whose `sourceBranch` exactly matches, download artifact `drop` with `curl --fail --location --user ":$AZURE_DEVOPS_TOKEN"`, and unzip it under a temporary source directory.
+8. Install `build`, `packaging`, and `twine`; run `python -m build --sdist --outdir dist` from the checked-out commit.
+9. In inline Python, copy all discovered wheels into `dist` while rejecting duplicate basenames before copying. Parse wheel and sdist filenames with `packaging.utils`, require project `questdb` and the requested version, and compare CPython wheels against the matrix represented by the current CI files:
+   - CPython 3.10–3.13 plus CPython 3.14 and 3.14t on manylinux and musllinux, each for x86_64 and aarch64;
+   - the same CPython set on macOS x86_64 and arm64;
+   - CPython 3.10–3.14, without free-threaded builds, on win32 and win_amd64;
+   - one or more PyPy 3 wheels on Linux x86_64;
+   - no other wheel targets and exactly one `.tar.gz`.
+10. Run `python -m twine check dist/*`.
+11. Extract the matching changelog section to `release-notes.md`. Convert its RST underline headings to Markdown headings, double-backtick literals to Markdown code spans, and Sphinx `:role:` links to readable labels without trying to implement a general RST converter.
+12. Write source run URLs, release SHA, and a sorted package list to `$GITHUB_STEP_SUMMARY`.
+13. Upload `dist/` and `release-notes.md` as `release-bundle` with `actions/upload-artifact@v4`, `retention-days: 7`, and `if-no-files-found: error`.
+
+- [ ] **Step 3: Run static and semantic checks**
+
+```bash
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"
+python - <<'PY'
+from pathlib import Path
+s = Path('.github/workflows/release.yml').read_text()
+for required in (
+    'workflow_dispatch:', 'github.ref', 'merge-base --is-ancestor',
+    '.bumpversion.toml', 'wheels-macos-arm64', 'definitions=21',
+    'python -m build --sdist', 'python -m twine check',
+    'actions/upload-artifact@v4', 'retention-days: 7',
+):
+    assert required in s, required
+assert 'twine upload' not in s
+PY
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 4: Exercise the wheel validator with representative names**
+
+Run the workflow's inline validator logic locally against a temporary fixture containing representative `questdb-5.0.1` filenames for every required target, then repeat with one required wheel removed, one wrong-version wheel, and a duplicate basename from two source directories.
+
+Expected: the complete fixture passes; each mutated fixture fails with the relevant filename or missing target in its error.
+
+- [ ] **Step 5: Commit the preparation job**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: prepare validated release bundles"
+```
+
+---
+
+### Task 2: Add protected publishing and recovery behavior
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+**Interfaces:**
+- Consumes: Task 1 outputs and `release-bundle`; environment `pypi`; environment secret `READTHEDOCS_TOKEN`; GitHub OIDC.
+- Produces: PyPI version, immutable `v<version>` tag, GitHub release with attached packages, and a successful ReadTheDocs `latest` build.
+
+- [ ] **Step 1: Write a failing protected-publish structural check**
+
+```bash
+python - <<'PY'
+from pathlib import Path
+s = Path('.github/workflows/release.yml').read_text()
+for required in ('publish:', 'environment: pypi', 'id-token: write',
+                 'pypa/gh-action-pypi-publish@release/v1',
+                 'READTHEDOCS_TOKEN', '/versions/latest/builds/'):
+    assert required in s, required
+PY
+```
+
+Expected: FAIL at `publish:`.
+
+- [ ] **Step 2: Add the protected publish job**
+
+Add a `publish` job that:
+
+```yaml
+  publish:
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-bundle
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+```
+
+Before publishing, fetch tags and require any existing `v<version>` tag to resolve to `release_sha`; fail rather than deleting or moving it. After PyPI succeeds:
+
+1. Create and push a lightweight tag only when absent.
+2. Use `gh release create` when the release is absent; otherwise use `gh release edit` and `gh release upload --clobber`. In both paths use `release-notes.md`, title `QuestDB Python client <version>`, and attach `dist/*`.
+3. Trigger `POST https://app.readthedocs.org/api/v3/projects/py-questdb-client/versions/latest/builds/` with `Authorization: Token $READTHEDOCS_TOKEN`.
+4. Parse the returned build ID and poll `GET /api/v3/projects/py-questdb-client/builds/<ID>/` every 15 seconds for at most 30 minutes. Succeed only when `state.code == finished` and `success == true`; fail immediately on `cancelled` or a finished unsuccessful build.
+5. Always put the PyPI, GitHub release, and ReadTheDocs build URLs in `$GITHUB_STEP_SUMMARY`.
+
+Keep the PyPI action before tag/release creation: if GitHub or ReadTheDocs fails afterward, `skip-existing`, the immutable-tag check, release update behavior, and safe repeated docs trigger allow a rerun.
+
+- [ ] **Step 3: Run static safety checks**
+
+```bash
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"
+python - <<'PY'
+from pathlib import Path
+s = Path('.github/workflows/release.yml').read_text()
+for required in (
+    'environment: pypi', 'contents: write', 'id-token: write',
+    'pypa/gh-action-pypi-publish@release/v1', 'skip-existing: true',
+    'gh release create', 'gh release edit', 'gh release upload',
+    'READTHEDOCS_TOKEN', 'state.code', 'success',
+):
+    assert required in s, required
+for forbidden in ('twine upload', 'git tag -f', 'git push --force'):
+    assert forbidden not in s, forbidden
+assert s.index('pypa/gh-action-pypi-publish@release/v1') < s.index('gh release create')
+PY
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 4: Review permission and secret boundaries**
+
+Confirm from the YAML that `prepare` has no `contents: write` or `id-token: write`, `publish` alone names `environment: pypi`, `AZURE_DEVOPS_TOKEN` appears only in prepare, and `READTHEDOCS_TOKEN` appears only in publish.
+
+Expected: no publishing credential is available before approval.
+
+- [ ] **Step 5: Commit protected publishing**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: publish approved releases"
+```
+
+---
+
+### Task 3: Replace the manual operator runbook and verify the complete change
+
+**Files:**
+- Modify: `RELEASING.rst`
+
+**Interfaces:**
+- Consumes: final workflow input names, secret names, and job behavior from Tasks 1–2.
+- Produces: the maintainer and administrator setup/runbook.
+
+- [ ] **Step 1: Write a failing documentation check**
+
+```bash
+python - <<'PY'
+from pathlib import Path
+s = Path('RELEASING.rst').read_text()
+for required in ('Run workflow', 'release_pr', 'Trusted Publishing',
+                 'AZURE_DEVOPS_TOKEN', 'READTHEDOCS_TOKEN'):
+    assert required in s, required
+PY
+```
+
+Expected: FAIL because the current runbook documents manual artifact collection.
+
+- [ ] **Step 2: Rewrite `RELEASING.rst` as the automated runbook**
+
+Retain the existing platform/wheel overview, then replace workstation artifact collection, browser tagging, token-based Twine upload, and manual ReadTheDocs sections with:
+
+1. **One-time administrator setup:** create protected `pypi` environment with required reviewers; register PyPI Trusted Publisher for repository `questdb/py-questdb-client`, workflow `release.yml`, environment `pypi`; add repository secret `AZURE_DEVOPS_TOKEN` with Azure build-read scope; add `READTHEDOCS_TOKEN` to the `pypi` environment.
+2. **Prepare release PR:** update changelog/version using `bump-my-version`, make the changelog date the intended UTC release date, and merge only after Azure and macOS ARM wheel checks pass.
+3. **Run release:** Actions → Release → Run workflow on `main`; enter version without `v` and merged PR number; inspect the prepare summary; approve the `pypi` job.
+4. **Verify:** follow workflow links to PyPI, GitHub release, and ReadTheDocs.
+5. **Recover:** rerun failed jobs with the same inputs; never move an existing tag; investigate any tag-to-commit mismatch.
+
+- [ ] **Step 3: Run documentation and workflow checks**
+
+```bash
+python - <<'PY'
+from pathlib import Path
+s = Path('RELEASING.rst').read_text()
+for required in ('Run workflow', 'release_pr', 'Trusted Publishing',
+                 'AZURE_DEVOPS_TOKEN', 'READTHEDOCS_TOKEN',
+                 'rerun', 'vX.Y.Z'):
+    assert required in s, required
+for obsolete in ('~/Downloads/drop', 'python3 -m twine upload dist/*',
+                 'Log into ReadTheDocs and trigger'):
+    assert obsolete not in s, obsolete
+PY
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"
+git diff --check
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 4: Verify the final diff and known non-live limitation**
+
+```bash
+git diff --stat HEAD~2
+git status --short
+git log -3 --oneline
+```
+
+Confirm the implementation changes only `.github/workflows/release.yml` and `RELEASING.rst` beyond the already-approved spec/plan. Record that real Azure download, Trusted Publishing, GitHub release creation, and ReadTheDocs triggering require administrator configuration and therefore were not executed locally.
+
+- [ ] **Step 5: Commit the runbook**
+
+```bash
+git add RELEASING.rst
+git commit -m "docs: automate the release runbook"
+```

--- a/docs/superpowers/specs/2026-08-12-release-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-12-release-workflow-design.md
@@ -1,0 +1,100 @@
+# Automated release workflow design
+
+## Goal
+
+Replace the workstation-based release steps with one manually dispatched GitHub Actions workflow. A maintainer enters a version and merged release PR number, reviews the prepared artifacts, and approves one protected job to publish the release.
+
+The version and changelog PR remains a human-reviewed process. Existing Azure and GitHub wheel builders remain unchanged.
+
+## Scope
+
+The change will add one self-contained `.github/workflows/release.yml` and update `RELEASING.rst`. It will not add a release service, repository-owned release program, or wheel-builder migration.
+
+The workflow may use GitHub-maintained actions, GitHub's preinstalled `gh` CLI, standard runner shell/Python, packaging utilities, and PyPA's recommended PyPI publishing action. Release-specific validation stays inline in the workflow.
+
+## Trigger and inputs
+
+The workflow uses `workflow_dispatch` with two required inputs:
+
+- `version`, without a `v` prefix, such as `5.0.1`
+- `release_pr`, the merged version/changelog PR number
+
+Only a dispatch from the default `main` branch is accepted. A release concurrency group prevents two release runs from publishing concurrently.
+
+## Prepare job: no approval and no external changes
+
+The first job performs all read-only checks and artifact preparation:
+
+1. Fetch the PR through the GitHub API and require that it:
+   - is merged;
+   - targets `main`;
+   - comes from this repository rather than a fork;
+   - has a merge commit reachable from the current `origin/main`.
+2. Check out the PR merge commit with submodules.
+3. Validate the version input and require all files listed in `.bumpversion.toml` to contain that version.
+4. Require the matching top-level `CHANGELOG.rst` section to have today's UTC date and not say `unreleased`.
+5. Locate the successful `macOS arm64 wheels` pull-request run associated with the supplied PR and download `wheels-macos-arm64` with the GitHub API/CLI.
+6. Query Azure DevOps pipeline definition 21 for the newest successful pull-request build of `refs/pull/<PR>/merge`, then download its `drop` artifact using a read-only Azure token.
+7. Collect wheels without silently overwriting duplicate filenames.
+8. Build exactly one source distribution from the checked-out release commit.
+9. Validate that:
+   - every distribution is for project `questdb` and the requested version;
+   - each required CPython/platform combination in the current CI configuration is present exactly once;
+   - Linux PyPy x86_64 wheels are present;
+   - no unexpected wheel, duplicate filename, or extra source distribution is present;
+   - `twine check` succeeds for every distribution.
+10. Extract the requested changelog section and perform minimal RST-to-Markdown cleanup for the GitHub release body.
+11. Write a GitHub job summary containing the release commit, source CI runs, file count, and sorted distribution list.
+12. Upload the validated `dist/` directory and generated release notes as one short-retention GitHub Actions artifact for the publish job.
+
+Any ambiguity—multiple candidate runs, missing artifacts, wrong versions, or a changed wheel matrix—fails before approval.
+
+## Publish job: protected environment
+
+A second job depends on the prepare job and uses the protected GitHub environment `pypi`. Required reviewers provide the final release approval. The job receives only the already-validated artifact; it does not rebuild packages.
+
+After approval it:
+
+1. Downloads the prepared artifact.
+2. Rechecks tag state. `v<version>` may be absent or already point to the selected release commit; a tag pointing elsewhere fails.
+3. Publishes `dist/*` through PyPI Trusted Publishing using PyPA's recommended action. Existing files are skipped to make recovery from a partial prior upload possible.
+4. Creates the tag and GitHub release at the selected release commit, using the generated notes, and attaches the distributions. If the same release already exists at the correct commit, it is updated rather than duplicated.
+5. Triggers a ReadTheDocs build for the `latest` version through API v3 and polls until it succeeds or reaches a bounded timeout. A docs failure is reported clearly but does not pretend that the already-published PyPI release was rolled back.
+6. Writes direct links to PyPI, the GitHub release, and the ReadTheDocs build in the job summary.
+
+## Authentication and repository setup
+
+An administrator must configure:
+
+- GitHub environment `pypi`, with required reviewers;
+- a PyPI Trusted Publisher for this repository, workflow, and `pypi` environment;
+- repository secret `AZURE_DEVOPS_TOKEN`, scoped read-only to Azure build artifacts;
+- environment secret `READTHEDOCS_TOKEN`, authorized for `py-questdb-client`.
+
+The workflow requests only the GitHub permissions needed for Actions artifact reads, release/tag writes, PR reads, and PyPI OIDC. Secrets are never passed to PR workflows.
+
+## Failure and rerun behavior
+
+Preparation is side-effect free and can be rerun freely. Nothing reaches PyPI before protected-environment approval.
+
+Publishing spans multiple services and cannot be atomic. Steps are ordered and made idempotent so a maintainer can rerun after a partial failure:
+
+- PyPI ignores filenames already uploaded for the version;
+- the tag must point to the same release commit;
+- the GitHub release is created or updated, never duplicated;
+- triggering another ReadTheDocs build is safe.
+
+The workflow never deletes or moves an existing tag automatically.
+
+## Documentation and verification
+
+`RELEASING.rst` will describe:
+
+1. preparing and merging the version/changelog PR;
+2. opening **Actions → Release → Run workflow**;
+3. entering the version and PR number;
+4. reviewing the prepare summary;
+5. approving the `pypi` environment;
+6. following the result links.
+
+Implementation verification will include YAML parsing, shell syntax checks where extractable, checks of the inline validator against representative wheel filenames, and a review of the final workflow permissions and failure paths. Live publishing is intentionally not exercised during development.


### PR DESCRIPTION
## Summary

- add a manually dispatched release workflow that resolves a merged release PR and reuses SHA-bound GitHub/Azure wheel artifacts
- validate wheel coverage, provenance, sdist contents, filenames, and SHA-256 hashes before protected PyPI Trusted Publishing
- support safe reruns, GitHub release creation, and validated Read the Docs triggering/monitoring
- replace the manual release guide with operator and administrator setup instructions

## Validation

- `python test/test.py -v` — 861 passed, 45 skipped
- workflow YAML parsing; `bash -n` and error-level ShellCheck for all 18 run blocks; inline Python compilation
- `actionlint -shellcheck= .github/workflows/release.yml`
- offline artifact-provenance, PyPI-integrity, and Read the Docs fixtures
- clean-clone sdist build — 831 members, 4.26 MB, required Rust/Python sources present, `twine check` passed
- `docutils` parsing and `git diff --check`

## Required before first live release

- configure protected GitHub environment `pypi` with required reviewers and `main` deployment protection
- configure the PyPI Trusted Publisher for `release.yml` / environment `pypi`
- add repository secret `AZURE_DEVOPS_TOKEN` with Azure Build Read access
- add `READTHEDOCS_TOKEN` to the `pypi` environment

Live publication services were intentionally not exercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a controlled, manually triggered release process that validates versions, changelogs, commits, and build artifacts before publication.
  * Automated publishing packages to PyPI, creating GitHub releases, and updating Read the Docs.
  * Added safe rerun and recovery handling with detailed validation and publication summaries.

* **Documentation**
  * Replaced workstation-based release instructions with guidance for preparing, running, verifying, and recovering automated releases.
  * Added release workflow design and implementation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->