### PR TITLE
build(arrow): enforce pinned FFI model in wheels

### DIFF
--- a/.github/workflows/macos-arm64-wheels.yml
+++ b/.github/workflows/macos-arm64-wheels.yml
@@ -24,7 +24,7 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install cibuildwheel
       - name: Build wheels
-        run: cibuildwheel --output-dir wheelhouse .
+        run: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
         env:
           CIBW_ARCHS_MACOS: arm64
           MACOSX_DEPLOYMENT_TARGET: "11.0"

--- a/ci/cibuildwheel.yaml
+++ b/ci/cibuildwheel.yaml
@@ -13,6 +13,8 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: true
+          - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               sudo find /etc/apt -name '*.list' -o -name '*.sources' \
@@ -22,7 +24,7 @@ stages:
               python3 -m pip install --upgrade pip --break-system-packages
               python3 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
-          - bash: python3 -m cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp310-manylinux_aarch64 cp311-manylinux_aarch64 cp312-manylinux_aarch64"
@@ -38,6 +40,8 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: true
+          - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               sudo find /etc/apt -name '*.list' -o -name '*.sources' \
@@ -47,7 +51,7 @@ stages:
               python3 -m pip install --upgrade pip --break-system-packages
               python3 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
-          - bash: python3 -m cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp313*-manylinux_aarch64 cp314*-manylinux_aarch64"
@@ -63,6 +67,8 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: true
+          - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               sudo find /etc/apt -name '*.list' -o -name '*.sources' \
@@ -72,7 +78,7 @@ stages:
               python3 -m pip install --upgrade pip --break-system-packages
               python3 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
-          - bash: python3 -m cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp310-musllinux_aarch64 cp311-musllinux_aarch64 cp312-musllinux_aarch64"
@@ -88,6 +94,8 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: true
+          - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               sudo find /etc/apt -name '*.list' -o -name '*.sources' \
@@ -97,7 +105,7 @@ stages:
               python3 -m pip install --upgrade pip --break-system-packages
               python3 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
-          - bash: python3 -m cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp313*-musllinux_aarch64 cp314*-musllinux_aarch64"
@@ -109,12 +117,13 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
               python3 -m pip install cibuildwheel
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64"
@@ -126,12 +135,13 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
               python3 -m pip install cibuildwheel
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp313*-manylinux_x86_64 cp314*-manylinux_x86_64"
@@ -143,12 +153,13 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
               python3 -m pip install cibuildwheel
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp310-musllinux* cp311-musllinux* cp312-musllinux*"
@@ -160,12 +171,13 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
               python3 -m pip install cibuildwheel
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp313*-musllinux* cp314*-musllinux*"
@@ -177,12 +189,13 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
               python3 -m pip install cibuildwheel
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: pp*
@@ -195,12 +208,13 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
               python3 -m pip install cibuildwheel
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp310-* cp311-*"
@@ -217,12 +231,13 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
               python3 -m pip install cibuildwheel
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp312-* cp313-*"
@@ -234,12 +249,13 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
               python3 -m pip install cibuildwheel
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp314-*"
@@ -251,12 +267,13 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
               python3 -m pip install cibuildwheel
             displayName: Install dependencies
-          - bash: cibuildwheel --output-dir wheelhouse .
+          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp314t-*"
@@ -268,6 +285,7 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
@@ -285,7 +303,7 @@ stages:
               }
 
               where.exe cl.exe
-              cibuildwheel --output-dir wheelhouse .
+              python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_ENVIRONMENT: "MSSdk=1 DISTUTILS_USE_SDK=1 SETUP_DO_GIT_SUBMODULE_INIT=1"
@@ -301,6 +319,7 @@ stages:
         timeoutInMinutes: 120
         steps:
           - task: UsePythonVersion@0
+            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               python3 -m pip install --upgrade pip
@@ -318,7 +337,7 @@ stages:
               }
 
               where.exe cl.exe
-              cibuildwheel --output-dir wheelhouse .
+              python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               # List versions explicitly, as the other jobs do. A `*win_amd64*`

--- a/ci/run_cibuildwheel.py
+++ b/ci/run_cibuildwheel.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Run the Arrow lock guard before delegating to cibuildwheel."""
+
+import pathlib
+import subprocess
+import sys
+
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def main():
+    subprocess.check_call([
+        sys.executable,
+        str(PROJECT_ROOT / 'c-questdb-client' / 'ci' /
+            'check_arrow_ffi_lock.py'),
+    ])
+    subprocess.check_call([
+        sys.executable,
+        '-m',
+        'cibuildwheel',
+        *sys.argv[1:],
+    ], cwd=PROJECT_ROOT)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -156,8 +156,9 @@ def cargo_build():
     # the released 2.x wheels: the knob is off by default at runtime and must
     # be explicitly set in the conf string, so compiling it in is safe.
     features = ['confstr-ffi', 'arrow', 'insecure-skip-verify']
+    ffi_cargo_args = cargo_args + ['--locked']
     subprocess.check_call(
-        cargo_args + ['--features', ','.join(features)],
+        ffi_cargo_args + ['--features', ','.join(features)],
         cwd=str(PROJ_ROOT / 'c-questdb-client' / 'questdb-rs-ffi'),
         env=env)
 

--- a/test/forged_arrow.py
+++ b/test/forged_arrow.py
@@ -377,21 +377,13 @@ def columns(rows, geohash=True, **column):
 # Native validation reads these before Arrow import, independently of field
 # metadata and row count. Two of the cases therefore carry no rows at all.
 
-@_case('schema_count_absurd')
-def _schema_count_absurd():
-    """A count both structs agree on, far past any array either of them
-    allocated. Agreement is what a plain equality check cannot see
-    through, which is why the count answers to a bound of its own."""
+@_case(
+    'root_column_count_cap_plus_one',
+    message='Arrow schema root: root column count 4096 exceeds 4095')
+def _root_column_count_cap_plus_one():
     return _RawArrowStream(
         columns(1, geohash=False), 1,
-        schema_n_children=1 << 40, batch_n_children=1 << 40)
-
-
-@_case('schema_per_node_count_cap_plus_one')
-def _schema_per_node_count_cap_plus_one():
-    return _RawArrowStream(
-        columns(1, geohash=False), 1,
-        schema_n_children=65537, batch_n_children=65537)
+        schema_n_children=4096, batch_n_children=4096)
 
 
 @_case('schema_count_negative')


### PR DESCRIPTION
## Summary

- pin the submodule to c-questdb-client Stage 2/3 PR #197 at 30d462e1cdf639466ddbc558a6e44919ff5b8016
- pass --locked only to the questdb-rs-ffi Cargo build used by Python artifacts
- run the single Arrow 59 lock guard through one wrapper before every cibuildwheel job, using Python 3.12 orchestration
- replace the obsolete forged count case with a deterministic 4,096-column rejection before its poison children pointer is read

## Dependency and landing gate

This follow-up is based on the current PR #140 head 59ec979. Its gitlink points to c-questdb-client PR #197, which depends on Stage 1 PR #196 and baseline PR #195. This development pin must not land until the dependency chain is merged and the gitlink is refreshed to a commit contained in c-questdb-client/main.

## Validation

- in-place Python extension build, exercising setup.py's --locked FFI build
- every registered forged Arrow stream in an isolated child process: passed with no rejected payload reaching the wire
- real pandas/pyarrow export with 4,095 Int64 columns: passed
- Arrow FFI guard: 11 Arrow-family lock packages at 59.0.0
- c-questdb-client docs check: 12 files, 85 local links
- all 15 Azure cibuildwheel invocations and the macOS arm64 GitHub job route through ci/run_cibuildwheel.py
- all modified YAML files parse successfully
- Python bytecode compilation and git diff checks pass

The complete native model, differential tests, exact dependency guard, and Cargo invocation audit are in c-questdb-client PR #197.