### PR TITLE
test(arrow): exhaust guarded FFI regressions

### DIFF
--- a/.github/workflows/grids.yml
+++ b/.github/workflows/grids.yml
@@ -3,8 +3,8 @@ name: Enumerated grids
 # The three grids that ended the PR #140 review cycle. Deliberately not a
 # pull-request gate: re-entrancy and concurrency spawn a subprocess per cell
 # and take minutes, and a gate that slow gets skipped rather than read. They run
-# nightly, and on demand from the Actions tab when a change touches the
-# guard, claim, or dataframe-planner areas.
+# nightly and on demand from the Actions tab. Guard Malloc is not part of a
+# scheduled run; it runs only when a manual dispatch sets `guard_malloc`.
 on:
   schedule:
     # 03:20 UTC, off the hour so it does not queue behind everyone else's

--- a/ci/cibuildwheel.yaml
+++ b/ci/cibuildwheel.yaml
@@ -13,18 +13,17 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: true
-          - task: UsePythonVersion@0
-            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               sudo find /etc/apt -name '*.list' -o -name '*.sources' \
                   | sudo xargs -r sed -i 's|http://ports.ubuntu.com|https://ports.ubuntu.com|g'
               sudo apt-get update --error-on=any
-              sudo apt-get install -y python3-pip python3-venv
-              python3 -m pip install --upgrade pip --break-system-packages
-              python3 -m pip install cibuildwheel --break-system-packages
+              sudo apt-get install -y python3.12 python3-pip python3.12-venv
+              python3.12 --version
+              python3.12 -m pip install --upgrade pip --break-system-packages
+              python3.12 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
-          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
+          - bash: python3.12 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp310-manylinux_aarch64 cp311-manylinux_aarch64 cp312-manylinux_aarch64"
@@ -40,18 +39,17 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: true
-          - task: UsePythonVersion@0
-            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               sudo find /etc/apt -name '*.list' -o -name '*.sources' \
                   | sudo xargs -r sed -i 's|http://ports.ubuntu.com|https://ports.ubuntu.com|g'
               sudo apt-get update --error-on=any
-              sudo apt-get install -y python3-pip python3-venv
-              python3 -m pip install --upgrade pip --break-system-packages
-              python3 -m pip install cibuildwheel --break-system-packages
+              sudo apt-get install -y python3.12 python3-pip python3.12-venv
+              python3.12 --version
+              python3.12 -m pip install --upgrade pip --break-system-packages
+              python3.12 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
-          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
+          - bash: python3.12 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp313*-manylinux_aarch64 cp314*-manylinux_aarch64"
@@ -67,18 +65,17 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: true
-          - task: UsePythonVersion@0
-            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               sudo find /etc/apt -name '*.list' -o -name '*.sources' \
                   | sudo xargs -r sed -i 's|http://ports.ubuntu.com|https://ports.ubuntu.com|g'
               sudo apt-get update --error-on=any
-              sudo apt-get install -y python3-pip python3-venv
-              python3 -m pip install --upgrade pip --break-system-packages
-              python3 -m pip install cibuildwheel --break-system-packages
+              sudo apt-get install -y python3.12 python3-pip python3.12-venv
+              python3.12 --version
+              python3.12 -m pip install --upgrade pip --break-system-packages
+              python3.12 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
-          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
+          - bash: python3.12 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp310-musllinux_aarch64 cp311-musllinux_aarch64 cp312-musllinux_aarch64"
@@ -94,18 +91,17 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: true
-          - task: UsePythonVersion@0
-            inputs: {versionSpec: "3.12"}
           - bash: |
               set -o errexit
               sudo find /etc/apt -name '*.list' -o -name '*.sources' \
                   | sudo xargs -r sed -i 's|http://ports.ubuntu.com|https://ports.ubuntu.com|g'
               sudo apt-get update --error-on=any
-              sudo apt-get install -y python3-pip python3-venv
-              python3 -m pip install --upgrade pip --break-system-packages
-              python3 -m pip install cibuildwheel --break-system-packages
+              sudo apt-get install -y python3.12 python3-pip python3.12-venv
+              python3.12 --version
+              python3.12 -m pip install --upgrade pip --break-system-packages
+              python3.12 -m pip install cibuildwheel --break-system-packages
             displayName: Install dependencies
-          - bash: python3 ci/run_cibuildwheel.py --output-dir wheelhouse .
+          - bash: python3.12 ci/run_cibuildwheel.py --output-dir wheelhouse .
             displayName: Build wheels
             env:
               CIBW_BUILD: "cp313*-musllinux_aarch64 cp314*-musllinux_aarch64"
@@ -116,6 +112,10 @@ stages:
         pool: {vmImage: 'ubuntu-latest'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -134,6 +134,10 @@ stages:
         pool: {vmImage: 'ubuntu-latest'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -152,6 +156,10 @@ stages:
         pool: {vmImage: 'ubuntu-latest'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -170,6 +178,10 @@ stages:
         pool: {vmImage: 'ubuntu-latest'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -188,6 +200,10 @@ stages:
         pool: {vmImage: 'ubuntu-latest'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -207,6 +223,10 @@ stages:
         pool: {vmImage: 'macOS-15'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -230,6 +250,10 @@ stages:
         pool: {vmImage: 'macOS-15'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -248,6 +272,10 @@ stages:
         pool: {vmImage: 'macOS-15'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -266,6 +294,10 @@ stages:
         pool: {vmImage: 'macOS-15'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -284,6 +316,10 @@ stages:
         pool: {vmImage: 'windows-2025'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |
@@ -318,6 +354,10 @@ stages:
         pool: {vmImage: 'windows-2025'}
         timeoutInMinutes: 120
         steps:
+          - checkout: self
+            fetchDepth: 1
+            lfs: false
+            submodules: true
           - task: UsePythonVersion@0
             inputs: {versionSpec: "3.12"}
           - bash: |

--- a/ci/pip_install_deps.py
+++ b/ci/pip_install_deps.py
@@ -11,6 +11,8 @@ arg_parser = argparse.ArgumentParser(
 )
 
 arg_parser.add_argument('--pandas-version')
+arg_parser.add_argument('--pyarrow-version')
+arg_parser.add_argument('--polars-version')
 
 
 class UnsupportedDependency(Exception):
@@ -100,8 +102,8 @@ def main(args):
         install_default_pandas_and_numpy()
 
     try_pip_install('fastparquet>=2023.10.1')
-    try_pip_install('pyarrow')
-    try_pip_install('polars')
+    try_pip_install('pyarrow', args.pyarrow_version or None)
+    try_pip_install('polars', args.polars_version or None)
     try_pip_install('psutil')
 
     on_linux_is_glibc = (

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -1,5 +1,10 @@
 trigger: none
 
+variables:
+  pyarrowVersion: ""
+  polarsVersion: ""
+  arrowProducerPins: ""
+
 stages:
   - stage: BuildAndTest
     displayName: "Building and testing"
@@ -21,6 +26,9 @@ stages:
               poolName: "Azure Pipelines"
               pythonVersion: "3.12"
               pandasVersion: "2.3.3"
+              pyarrowVersion: "25.0.1"
+              polarsVersion: "1.44.1"
+              arrowProducerPins: "pandas=2.3.3,pyarrow=25.0.1,polars=1.44.1"
               questdbVersion: ""
               requireQwpRowTypes: ""
             linux-pandas310:
@@ -84,10 +92,17 @@ stages:
               python3 --version
               python3 -m pip install cython
             displayName: "Install cython"
-          - script: python3 ci/pip_install_deps.py
+          - script: >-
+              python3 ci/pip_install_deps.py
+              --pyarrow-version=$(pyarrowVersion)
+              --polars-version=$(polarsVersion)
             displayName: "Install pandas 3.x"
             condition: eq(variables.pandasVersion, '')
-          - script: python3 ci/pip_install_deps.py --pandas-version==$(pandasVersion)
+          - script: >-
+              python3 ci/pip_install_deps.py
+              --pandas-version=$(pandasVersion)
+              --pyarrow-version=$(pyarrowVersion)
+              --polars-version=$(polarsVersion)
             displayName: "Install pandas $(pandasVersion)"
             condition: ne(variables.pandasVersion, '')
           - script: python3 proj.py build
@@ -149,6 +164,7 @@ stages:
               JAVA_HOME: $(JAVA_HOME_25_X64)
               QDB_VERSION: $(questdbVersion)
               TEST_QUESTDB_REQUIRE_QWP_ROW_TYPES: $(requireQwpRowTypes)
+              TEST_QUESTDB_ARROW_PRODUCER_PINS: $(arrowProducerPins)
           - script: python3 proj.py test 1
             displayName: "Test vs master"
             env:

--- a/test/forged_arrow.py
+++ b/test/forged_arrow.py
@@ -12,7 +12,8 @@ producer and nothing else the suite imports, which is why this file stops at
 ctypes, struct and the client.
 
 Run as a script it builds one named case, sends it at the port it is
-given, requires a native ``ArrowIngest`` refusal, and prints ``MARKER``::
+given, requires the registered success or native refusal, and prints
+``MARKER``::
 
     TEST_QUESTDB_PATCH_PATH=1 QUESTDB_FORGED_ARROW_CASE=null_batch_child \
         QUESTDB_FORGED_ARROW_PORT=9009 python3 forged_arrow.py
@@ -87,7 +88,9 @@ class _RawArrowStream:
     def __init__(self, columns, row_count, batch_offset=0,
                  schema_n_children=None, batch_n_children=None,
                  null_schema_children=False, null_batch_children=False,
-                 null_schema_child=None, null_batch_child=None):
+                 null_schema_child=None, null_batch_child=None,
+                 poison_schema_children=False,
+                 poison_batch_children=False):
         """`columns` is a list of dicts, one per column, each naming its
         Arrow `format`, its `name`, the `data` bytes of its value
         buffer, and optionally `metadata`, `null_count`, `validity`,
@@ -110,10 +113,11 @@ class _RawArrowStream:
         self._released = False
         self._schema = self._build_schema(
             columns, schema_n_children, null_schema_children,
-            null_schema_child)
+            null_schema_child, poison_schema_children)
         self._array = self._build_array(
             columns, row_count, batch_offset, batch_n_children,
-            null_batch_children, null_batch_child)
+            null_batch_children, null_batch_child,
+            poison_batch_children)
         self._stream = self._build_stream()
 
     # -- construction --------------------------------------------------
@@ -169,11 +173,14 @@ class _RawArrowStream:
                 child = self._build_schema_node(child_def)
                 children[i] = ctypes.pointer(child)
             self._keep.append(children)
-            node.n_children = len(child_defs)
-            node.children = ctypes.cast(children, ctypes.c_void_p)
+            node.n_children = column.get('schema_n_children', len(child_defs))
+            node.children = (
+                None if column.get('null_schema_children')
+                else ctypes.cast(children, ctypes.c_void_p))
         else:
-            node.n_children = 0
-            node.children = None
+            node.n_children = column.get('schema_n_children', 0)
+            node.children = (
+                1 if column.get('poison_schema_children') else None)
         node.dictionary = None
         node.release = self._release_stub(self.Schema)
         node.private_data = None
@@ -181,7 +188,8 @@ class _RawArrowStream:
         return node
 
     def _build_schema(self, columns, n_children=None,
-                      null_children=False, null_child=None):
+                      null_children=False, null_child=None,
+                      poison_children=False):
         children = (ctypes.POINTER(self.Schema) * len(columns))()
         for i, column in enumerate(columns):
             child = self._build_schema_node(column)
@@ -197,8 +205,9 @@ class _RawArrowStream:
         top.n_children = (
             len(columns) if n_children is None else n_children)
         top.children = (
-            None if null_children
-            else ctypes.cast(children, ctypes.c_void_p))
+            1 if poison_children else (
+                None if null_children
+                else ctypes.cast(children, ctypes.c_void_p)))
         top.dictionary = None
         top.release = self._release_stub(self.Schema)
         top.private_data = None
@@ -226,11 +235,14 @@ class _RawArrowStream:
                 child = self._build_array_node(child_def, node.length)
                 children[i] = ctypes.pointer(child)
             self._keep.append(children)
-            node.n_children = len(child_defs)
-            node.children = ctypes.cast(children, ctypes.c_void_p)
+            node.n_children = column.get('array_n_children', len(child_defs))
+            node.children = (
+                None if column.get('null_array_children')
+                else ctypes.cast(children, ctypes.c_void_p))
         else:
-            node.n_children = 0
-            node.children = None
+            node.n_children = column.get('array_n_children', 0)
+            node.children = (
+                1 if column.get('poison_array_children') else None)
         node.dictionary = None
         node.release = self._release_stub(self.Array)
         node.private_data = None
@@ -239,7 +251,7 @@ class _RawArrowStream:
 
     def _build_array(self, columns, row_count, batch_offset,
                      n_children=None, null_children=False,
-                     null_child=None):
+                     null_child=None, poison_children=False):
         children = (ctypes.POINTER(self.Array) * len(columns))()
         for i, column in enumerate(columns):
             child = self._build_array_node(column, row_count + batch_offset)
@@ -256,8 +268,9 @@ class _RawArrowStream:
             len(columns) if n_children is None else n_children)
         top.buffers = self._buffer_array([None])
         top.children = (
-            None if null_children
-            else ctypes.cast(children, ctypes.c_void_p))
+            1 if poison_children else (
+                None if null_children
+                else ctypes.cast(children, ctypes.c_void_p)))
         top.dictionary = None
         top.release = self._release_stub(self.Array)
         top.private_data = None
@@ -328,28 +341,32 @@ _RawArrowStream.Schema._fields_ = _RawArrowStream._SCHEMA_FIELDS
 _RawArrowStream.Stream._fields_ = _RawArrowStream._STREAM_FIELDS
 
 
-#: Printed by a child that saw the refusal it was sent to provoke. The
+#: Printed by a child that observed its declared success/refusal outcome. The
 #: parent requires it, so an early `sys.exit(0)` cannot pass for one.
-MARKER = 'FORGED-ARROW-REFUSED-OK'
+MARKER = 'FORGED-ARROW-OUTCOME-OK'
 
 #: Case name -> builder for one malformed Arrow stream.
 FORGED_CASES = {}
 FORGED_EXPECTATIONS = {}
 
-_STAMP = struct.pack('<q', 1735689600000000)
+_STAMP_MICROS = 1735689600000000
 _GEOHASH_CLAIM = {b'questdb.column_type': b'geohash',
                   b'questdb.geohash_bits': b'5'}
 
 
-def _case(name, *, code='ArrowIngest', message=None, at='ts'):
-    """Register a forged shape under `name`."""
+def _case(name, *, outcome='ArrowIngest', message=None, at='ts',
+          wire=False, row_count=None, wire_contains=()):
+    """Register an ABI-conforming hand-built shape and its full outcome."""
     def register(build):
         assert name not in FORGED_CASES, name
         FORGED_CASES[name] = build
         FORGED_EXPECTATIONS[name] = {
-            'code': code,
+            'outcome': outcome,
             'message': message,
             'at': at,
+            'wire': wire,
+            'row_count': row_count,
+            'wire_contains': tuple(wire_contains),
         }
         return build
     return register
@@ -367,9 +384,14 @@ def columns(rows, geohash=True, **column):
     """
     return [
         dict(format=b'i', name=b'gh',
-             data=struct.pack('<%di' % rows, *([1] * rows)),
+             data=struct.pack('<%di' % rows, *range(101, 101 + rows)),
              metadata=_GEOHASH_CLAIM if geohash else None, **column),
-        dict(format=b'tsu:UTC', name=b'ts', data=_STAMP * rows, **column)]
+        dict(
+            format=b'tsu:UTC', name=b'ts',
+            data=struct.pack(
+                '<%dq' % rows,
+                *(_STAMP_MICROS + i * 1_000_000 for i in range(rows))),
+            **column)]
 
 
 # -- counts and child pointers -----------------------------------------
@@ -383,29 +405,40 @@ def columns(rows, geohash=True, **column):
 def _root_column_count_cap_plus_one():
     return _RawArrowStream(
         columns(1, geohash=False), 1,
-        schema_n_children=4096, batch_n_children=4096)
+        schema_n_children=4096, batch_n_children=4096,
+        poison_schema_children=True, poison_batch_children=True)
 
 
-@_case('schema_count_negative')
+@_case(
+    'schema_count_negative',
+    message='Arrow schema root: n_children -1 is negative')
 def _schema_count_negative():
     return _RawArrowStream(
         columns(1, geohash=False), 1,
         schema_n_children=-1, batch_n_children=-1)
 
 
-@_case('batch_count_negative')
+@_case(
+    'batch_count_negative',
+    message='Arrow array root: n_children -1 is negative')
 def _batch_count_negative():
     return _RawArrowStream(
         columns(1, geohash=False), 1, batch_n_children=-1)
 
 
-@_case('count_disagreement')
+@_case(
+    'count_disagreement',
+    message=('Arrow array root: n_children 3 disagrees with '
+             'schema n_children 2'))
 def _count_disagreement():
     return _RawArrowStream(
         columns(1, geohash=False), 1, batch_n_children=3)
 
 
-@_case('zero_column_schema_disagreement')
+@_case(
+    'zero_column_schema_disagreement',
+    message=('Arrow array root: n_children 2 disagrees with '
+             'schema n_children 0'))
 def _zero_column_schema_disagreement():
     """A zero-column schema is a shape the scan has nothing to do with,
     and the batch's own count still has to agree with it."""
@@ -413,37 +446,54 @@ def _zero_column_schema_disagreement():
         columns(1, geohash=False), 1, schema_n_children=0)
 
 
-@_case('zero_row_count_disagreement')
+@_case(
+    'zero_row_count_disagreement',
+    message=('Arrow array root: n_children 4 disagrees with '
+             'schema n_children 2'))
 def _zero_row_count_disagreement():
     return _RawArrowStream(
-        columns(1, geohash=False), 0, batch_n_children=3)
+        columns(1, geohash=False), 0, batch_n_children=4)
 
 
-@_case('null_schema_children')
+@_case(
+    'null_schema_children',
+    message=('Arrow schema root: declares 2 children but children '
+             'pointer is NULL'))
 def _null_schema_children():
     return _RawArrowStream(
         columns(1, geohash=False), 1, null_schema_children=True)
 
 
-@_case('null_batch_children')
+@_case(
+    'null_batch_children',
+    message=('Arrow array root: length 1 declares 2 children but '
+             'children pointer is NULL'))
 def _null_batch_children():
     return _RawArrowStream(
         columns(1, geohash=False), 1, null_batch_children=True)
 
 
-@_case('null_schema_child')
+@_case(
+    'null_schema_child',
+    message='Arrow schema root.children[0]: child pointer is NULL')
 def _null_schema_child():
     return _RawArrowStream(
         columns(1, geohash=False), 1, null_schema_child=0)
 
 
-@_case('null_batch_child')
+@_case(
+    'null_batch_child',
+    message=('Arrow array root.children[1]: array or schema child '
+             'pointer is NULL'))
 def _null_batch_child():
     return _RawArrowStream(
         columns(1, geohash=False), 1, null_batch_child=1)
 
 
-@_case('null_batch_children_zero_rows')
+@_case(
+    'null_batch_children_zero_rows',
+    message=('Arrow array root: length 0 declares 2 children but '
+             'children pointer is NULL'))
 def _null_batch_children_zero_rows():
     """A batch with no rows still has its struct read, so an empty one
     cannot carry a malformed shape past the checks."""
@@ -451,10 +501,12 @@ def _null_batch_children_zero_rows():
         columns(1, geohash=False), 0, null_batch_children=True)
 
 
-@_case('null_schema_child_zero_rows')
+@_case(
+    'null_schema_child_zero_rows',
+    message='Arrow schema root.children[1]: child pointer is NULL')
 def _null_schema_child_zero_rows():
     return _RawArrowStream(
-        columns(1, geohash=False), 0, null_schema_child=0)
+        columns(1, geohash=False), 0, null_schema_child=1)
 
 
 # -- unsupported nested columns and bounded metadata -------------------
@@ -478,7 +530,7 @@ def _nested_struct_stream(root_offset):
 
 @_case(
     'nested_struct_root_offset_zero',
-    code='ArrowUnsupportedColumnKind',
+    outcome='ArrowUnsupportedColumnKind',
     message='Arrow schema root.children[0]: Struct columns are not supported',
     at='server')
 def _nested_struct_root_offset_zero():
@@ -487,7 +539,7 @@ def _nested_struct_root_offset_zero():
 
 @_case(
     'nested_struct_root_offset_one',
-    code='ArrowUnsupportedColumnKind',
+    outcome='ArrowUnsupportedColumnKind',
     message='Arrow schema root.children[0]: Struct columns are not supported',
     at='server')
 def _nested_struct_root_offset_one():
@@ -495,8 +547,135 @@ def _nested_struct_root_offset_one():
 
 
 @_case(
+    'nested_struct_narrowed_to_zero_rows',
+    outcome='ArrowUnsupportedColumnKind',
+    message='Arrow schema root.children[0]: Struct columns are not supported',
+    at='server')
+def _nested_struct_narrowed_to_zero_rows():
+    stream = _nested_struct_stream(0)
+    stream._array.length = 0
+    return stream
+
+
+@_case(
+    'three_level_nested_struct',
+    outcome='ArrowUnsupportedColumnKind',
+    message='Arrow schema root.children[0]: Struct columns are not supported',
+    at='server')
+def _three_level_nested_struct():
+    leaf = {
+        'format': b'i', 'name': b'value', 'length': 2,
+        'data': struct.pack('<ii', 11, 22)}
+    inner = {
+        'format': b'+s', 'name': b'inner', 'length': 2,
+        'buffers': [None], 'children': [leaf]}
+    outer = {
+        'format': b'+s', 'name': b'outer', 'length': 2,
+        'buffers': [None], 'children': [inner]}
+    return _RawArrowStream([outer], 1)
+
+
+@_case(
+    'fixed_size_list_short_child',
+    message=('Arrow array root.children[0]: FixedSizeList slice offset 0 '
+             '+ length 2 with size 2 ends at 4, beyond child 0 length 3'),
+    at='server')
+def _fixed_size_list_short_child():
+    values = {
+        'format': b'g', 'name': b'item', 'length': 3,
+        'data': struct.pack('<ddd', 1.0, 2.0, 3.0)}
+    fixed = {
+        'format': b'+w:2', 'name': b'values', 'length': 2, 'offset': 0,
+        'buffers': [None], 'children': [values]}
+    return _RawArrowStream([fixed], 1, 1)
+
+
+@_case(
+    'list_missing_child',
+    message=('Arrow schema root.children[0]: format requires exactly 1 '
+             'normal child(ren) but declares 0'),
+    at='server')
+def _list_missing_child():
+    return _RawArrowStream([
+        {'format': b'+l', 'name': b'values', 'length': 1,
+         'buffers': [None, struct.pack('<ii', 0, 0)]}
+    ], 1)
+
+
+@_case(
+    'fixed_layout_buffer_count_below_exact',
+    message='Arrow array root.children[0]: declares 1 buffers but Int32 requires exactly 2',
+    at='server')
+def _fixed_layout_buffer_count_below_exact():
+    return _RawArrowStream([
+        {'format': b'i', 'name': b'value', 'length': 1,
+         'buffers': [None]}
+    ], 1)
+
+
+@_case(
+    'fixed_layout_buffer_count_above_exact',
+    message='Arrow array root.children[0]: declares 3 buffers but Int32 requires exactly 2',
+    at='server')
+def _fixed_layout_buffer_count_above_exact():
+    return _RawArrowStream([
+        {'format': b'i', 'name': b'value', 'length': 1,
+         'buffers': [None, struct.pack('<i', 7), b'extra']}
+    ], 1)
+
+
+@_case(
+    'view_buffer_count_below_minimum',
+    message=('Arrow array root.children[0]: view layout requires 3..=16 '
+             'buffers but declares 2'),
+    at='server')
+def _view_buffer_count_below_minimum():
+    return _RawArrowStream([
+        {'format': b'vu', 'name': b'value', 'length': 0,
+         'buffers': [None, None]}
+    ], 0)
+
+
+@_case(
+    'view_buffer_count_above_maximum',
+    message=('Arrow array root.children[0]: view layout requires 3..=16 '
+             'buffers but declares 17'),
+    at='server')
+def _view_buffer_count_above_maximum():
+    return _RawArrowStream([
+        {'format': b'vu', 'name': b'value', 'length': 0,
+         'buffers': [None] * 17}
+    ], 0)
+
+
+@_case(
+    'view_null_variadic_lengths_slot',
+    message=('Arrow array root.children[0]: view variadic-lengths buffer '
+             '(slot 3) is NULL'),
+    at='server')
+def _view_null_variadic_lengths_slot():
+    return _RawArrowStream([
+        {'format': b'vu', 'name': b'value', 'length': 1,
+         'buffers': [None, b'\x00' * 16, b'x', None]}
+    ], 1)
+
+
+@_case(
+    'utf8_null_offset_slot',
+    message=('Arrow array root.children[0]: variable-width offset buffer '
+             '(slot 1) is NULL'),
+    at='server')
+def _utf8_null_offset_slot():
+    return _RawArrowStream([
+        {'format': b'u', 'name': b'value', 'length': 1,
+         'buffers': [None, None, b'x']}
+    ], 1)
+
+
+@_case(
     'metadata_oversized_key_length',
-    message='metadata blob exceeds 1048576 bytes',
+    message=('Arrow schema root.children[0]: metadata blob exceeds '
+             '1048576 bytes'),
     at='server')
 def _metadata_oversized_key_length():
     column = dict(
@@ -507,7 +686,8 @@ def _metadata_oversized_key_length():
 
 @_case(
     'metadata_oversized_value_length',
-    message='metadata blob exceeds 1048576 bytes',
+    message=('Arrow schema root.children[0]: metadata blob exceeds '
+             '1048576 bytes'),
     at='server')
 def _metadata_oversized_value_length():
     column = dict(
@@ -516,56 +696,110 @@ def _metadata_oversized_value_length():
     return _RawArrowStream([column], 1)
 
 
+def _metadata_stream(blob):
+    return _RawArrowStream([
+        dict(format=b'i', name=b'value', data=struct.pack('<i', 1),
+             metadata_blob=blob)
+    ], 1)
+
+
+@_case(
+    'metadata_negative_entry_count',
+    message=('Arrow schema root.children[0]: metadata entry count -1 '
+             'is negative'),
+    at='server')
+def _metadata_negative_entry_count():
+    return _metadata_stream(struct.pack('<i', -1))
+
+
+@_case(
+    'metadata_entry_count_cap_plus_one',
+    message=('Arrow schema root.children[0]: metadata declares 65537 '
+             'entries, above maximum 65536'),
+    at='server')
+def _metadata_entry_count_cap_plus_one():
+    return _metadata_stream(struct.pack('<i', 65537))
+
+
+@_case(
+    'metadata_negative_key_length',
+    message=('Arrow schema root.children[0]: metadata entry 0 key '
+             'length -2 is negative'),
+    at='server')
+def _metadata_negative_key_length():
+    return _metadata_stream(struct.pack('<ii', 1, -2))
+
+
+@_case(
+    'metadata_negative_value_length',
+    message=('Arrow schema root.children[0]: metadata entry 0 value '
+             'length -3 is negative'),
+    at='server')
+def _metadata_negative_value_length():
+    return _metadata_stream(struct.pack('<iii', 1, 0, -3))
+
+
 # -- row shapes --------------------------------------------------------
 #
 # These exercise native length and offset validation. The GEOHASH metadata
 # preserves the production route that first exposed the malformed slices;
 # it does not gate the structural checks.
 
-@_case('batch_length_overflow')
-def _batch_length_overflow():
-    """The review's own reproduction: `batch.offset + batch.length`
-    leaves `int64_t` and lands as a large negative, which an unbounded
-    slice check reads as a batch comfortably inside its column."""
-    return _RawArrowStream(columns(1, length=1), (1 << 63) - 1, 1)
-
-
-@_case('batch_length_cap_plus_one')
+@_case(
+    'batch_length_cap_plus_one',
+    message='Arrow array root: length 16777217 exceeds 16777216')
 def _batch_length_cap_plus_one():
     return _RawArrowStream(columns(1, length=1), 16777217, 0)
 
 
-@_case('batch_offset_cap_plus_one')
+@_case(
+    'batch_offset_cap_plus_one',
+    message='Arrow array root: offset 16777217 exceeds 16777216')
 def _batch_offset_cap_plus_one():
     return _RawArrowStream(columns(1, length=1), 1, 16777217)
 
 
-@_case('batch_offset_negative')
+@_case(
+    'batch_offset_negative',
+    message='Arrow array root: offset -1 is negative')
 def _batch_offset_negative():
     return _RawArrowStream(columns(1, length=1), 1, -1)
 
 
-@_case('column_length_cap_plus_one')
+@_case(
+    'column_length_cap_plus_one',
+    message=('Arrow array root.children[1]: length 16777217 exceeds '
+             '16777216'))
 def _column_length_cap_plus_one():
     return _RawArrowStream(columns(1, length=16777217), 1, 0)
 
 
-@_case('column_length_negative')
+@_case(
+    'column_length_negative',
+    message='Arrow array root.children[1]: length -1 is negative')
 def _column_length_negative():
     return _RawArrowStream(columns(1, length=-1), 1, 0)
 
 
-@_case('column_offset_cap_plus_one')
+@_case(
+    'column_offset_cap_plus_one',
+    message=('Arrow array root.children[1]: offset 16777217 exceeds '
+             '16777216'))
 def _column_offset_cap_plus_one():
     return _RawArrowStream(columns(1, length=1, offset=16777217), 1, 0)
 
 
-@_case('column_offset_negative')
+@_case(
+    'column_offset_negative',
+    message='Arrow array root.children[1]: offset -1 is negative')
 def _column_offset_negative():
     return _RawArrowStream(columns(1, length=1, offset=-1), 1, 0)
 
 
-@_case('slice_past_column')
+@_case(
+    'slice_past_column',
+    message=('Arrow array root: Struct slice offset 1 + length 2 ends '
+             'at 3, beyond child 0 length 2'))
 def _slice_past_column():
     """One row past the column: `batch.offset + batch.length` comes to
     `col.length + 1`. Its twin, one row shorter, is sent for real by
@@ -573,15 +807,22 @@ def _slice_past_column():
     return _RawArrowStream(columns(3, length=2), 2, 1)
 
 
+@_case(
+    'slice_at_column_end',
+    outcome='success',
+    at='ts',
+    wire=True,
+    row_count=2,
+    wire_contains=(struct.pack('<qq', 102, 103),))
 def accepted_slice():
     """The shape `slice_past_column` is one row longer than: a batch
     ending exactly where its columns do. Built here so the two differ in
     a single number."""
-    return _RawArrowStream(columns(3, length=3), 2, 1)
+    return _RawArrowStream(columns(3, geohash=False, length=3), 2, 1)
 
 
 def run_case(name, port):
-    """Build the named shape and require a native Arrow refusal."""
+    """Build the named shape and require its declared native outcome."""
     build = FORGED_CASES[name]
     expected = FORGED_EXPECTATIONS[name]
     stream = build()
@@ -593,18 +834,22 @@ def run_case(name, port):
             at = qi.ServerTimestamp if expected['at'] == 'server' else expected['at']
             client.dataframe(stream, table_name='forged', at=at)
         except qi.QuestDBError as exc:
-            expected_code = getattr(qi.QuestDBErrorCode, expected['code'])
+            if expected['outcome'] == 'success':
+                raise AssertionError(
+                    f'{name}: expected success, got {exc.code!r}: {exc}') from None
+            expected_code = getattr(qi.QuestDBErrorCode, expected['outcome'])
             if exc.code is not expected_code:
                 raise AssertionError(
                     f'{name}: refused as {exc.code!r}, expected '
-                    f'{expected["code"]}: {exc}') from None
+                    f'{expected["outcome"]}: {exc}') from None
             if (expected['message'] is not None
                     and expected['message'] not in str(exc)):
                 raise AssertionError(
                     f'{name}: expected diagnostic {expected["message"]!r}, '
                     f'got: {exc}') from None
         else:
-            raise AssertionError(f'{name}: the forged stream was accepted')
+            if expected['outcome'] != 'success':
+                raise AssertionError(f'{name}: the forged stream was accepted')
     finally:
         client.close()
     print(MARKER)

--- a/test/test.py
+++ b/test/test.py
@@ -40,8 +40,7 @@ from forged_arrow import (
     FORGED_CASES,
     FORGED_EXPECTATIONS,
     MARKER as FORGED_ARROW_MARKER,
-    _RawArrowStream,
-    accepted_slice)
+    _RawArrowStream)
 
 PROJ_ROOT = patch_path.PROJ_ROOT
 sys.path.append(str(PROJ_ROOT / 'c-questdb-client' / 'system_test'))
@@ -93,6 +92,7 @@ _first_qwp_table_column_types = qwp_wire.first_table_column_types
 
 
 from test_client_capsule_path import (
+    TestArrowFfiProducerLayoutMatrix,
     TestCapsulePathPyArrow,
     TestCapsulePathPolars,
     TestServerTimestampAt,
@@ -2418,7 +2418,7 @@ class TestQwpOnlyRowTypes(unittest.TestCase):
     UUID_VALUE = uuid.UUID('123e4567-e89b-12d3-a456-426614174000')
 
     @_needs_capsule_builder
-    def test_every_forged_arrow_shape_is_refused_without_reaching_the_wire(self):
+    def test_every_forged_arrow_shape_has_its_declared_subprocess_outcome(self):
         script = pathlib.Path(__file__).with_name('forged_arrow.py')
         self.assertEqual(
             set(FORGED_CASES), set(FORGED_EXPECTATIONS),
@@ -2454,13 +2454,32 @@ class TestQwpOnlyRowTypes(unittest.TestCase):
                         f'stderr:\n{child.stderr}')
                 frames = server.wait_binary_frames_settled()
                 stats = server.snapshot()
-                self.assertEqual(
-                    frames, 0,
-                    f'{name}: malformed Arrow produced a binary frame')
-                self.assertEqual(
-                    stats['binary_payloads'], [],
-                    f'{name}: malformed Arrow payload reached the wire')
-                self.assertEqual(stats['binary_bytes'], 0)
+                expected = FORGED_EXPECTATIONS[name]
+                if expected['wire']:
+                    self.assertGreaterEqual(
+                        frames, 1,
+                        f'{name}: accepted Arrow produced no binary frame')
+                    data_frames = [
+                        payload for payload in stats['binary_payloads']
+                        if (payload[:4] == b'QWP1'
+                            and int.from_bytes(payload[6:8], 'little') > 0)]
+                    self.assertGreaterEqual(len(data_frames), 1)
+                    self.assertEqual(
+                        _first_qwp_table_row_count(data_frames[0]),
+                        expected['row_count'])
+                    payload = b''.join(data_frames)
+                    for encoded in expected['wire_contains']:
+                        self.assertIn(
+                            encoded, payload,
+                            f'{name}: representative encoded values missing')
+                else:
+                    self.assertEqual(
+                        frames, 0,
+                        f'{name}: rejected Arrow produced a binary frame')
+                    self.assertEqual(
+                        stats['binary_payloads'], [],
+                        f'{name}: rejected Arrow payload reached the wire')
+                    self.assertEqual(stats['binary_bytes'], 0)
                 self.assertGreaterEqual(stats['accepted_connections'], 1)
                 self.assertEqual(stats['errors'], [])
 
@@ -2487,20 +2506,6 @@ class TestQwpOnlyRowTypes(unittest.TestCase):
             stats = server.snapshot()
         self.assertEqual(stats['errors'], [])
         self.assertGreaterEqual(stats['accepted_connections'], 1)
-
-    @_needs_capsule_builder
-    def test_a_batch_ending_exactly_at_the_column_end_is_accepted(self):
-        with QwpAckServer(record_payloads=True) as server:
-            conf = (
-                f'ws::addr=127.0.0.1:{server.port};lazy_connect=true;'
-                'sender_pool_min=1;sender_pool_max=1;pool_reap=manual;')
-            with qi.QuestDB.from_conf(conf) as client:
-                client.dataframe(
-                    accepted_slice(), table_name='accepted_slice', at='ts')
-            self.assertGreaterEqual(server.wait_binary_frames_settled(), 1)
-            stats = server.snapshot()
-        self.assertEqual(stats['errors'], [])
-        self.assertGreaterEqual(len(stats['binary_payloads']), 1)
 
     def test_wrappers_exported(self):
         import questdb
@@ -6106,7 +6111,8 @@ class TestQwpOnlyRowTypes(unittest.TestCase):
                         Producer(), table_name='t', at='ts',
                         schema_overrides={'g': ('geohash', 5)})
         self.assertIn(
-            'Arrow array length -1 is negative', str(caught.exception))
+            'Arrow array root: length -1 is negative',
+            str(caught.exception))
         # Keep the trampolines alive until the send is over.
         self.assertIsNotNone(callbacks)
         self.assertIsNotNone(inner_capsule)
@@ -7157,8 +7163,8 @@ class TestQwpOnlyRowTypes(unittest.TestCase):
 
     @unittest.skipIf(pyarrow is None, 'pyarrow not installed')
     def test_big_metadata_on_a_non_geohash_column_does_not_stop_the_send(self):
-        """Large metadata on an unrelated column remains valid input."""
-        padding = {f'pad.{i}'.encode(): b'x' * 400 for i in range(5000)}
+        """Large metadata below the 1 MiB cap remains valid input."""
+        padding = {f'pad.{i}'.encode(): b'x' * 400 for i in range(2000)}
         stamp = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
         schema = pyarrow.schema([
             pyarrow.field('s', pyarrow.string(), metadata=padding),
@@ -7227,35 +7233,44 @@ class TestQwpOnlyRowTypes(unittest.TestCase):
     @unittest.skipIf(pyarrow is None, 'pyarrow not installed')
     def test_large_geohash_metadata_uses_the_native_importer(self):
         # Python no longer duplicates the importer's metadata parser or
-        # walks the values. Large metadata is handled natively and wide
-        # values are forwarded under the same unchecked contract.
-        oversized = (
-            ('more pairs than the walk covers',
-             {f'pad.{i}'.encode(): b'x' for i in range(5000)}),
-            ('one value longer than the byte budget',
-             {b'pad.big': b'x' * (2 << 20)}))
-        for name, padding in oversized:
-            with self.subTest(blob=name, claim=True):
-                md = dict(padding)
-                md[b'questdb.column_type'] = b'geohash'
-                md[b'questdb.geohash_bits'] = b'20'
-                self.assertEqual(
-                    self._dataframe_column_types(
-                        self._geohash_arrow_table([2 ** 21], md=md),
-                        table_name='geo_md_long', at='ts')['gh'],
-                    0x0E)
-            # A blob this long that claims nothing is a column with a
-            # lot of metadata, not a hidden geohash. Refusing it was the
-            # clearest over-refusal the old rule produced. It goes out
-            # as the integer it is.
-            with self.subTest(blob=name, claim=False):
-                self.assertEqual(
-                    self._dataframe_column_types(
-                        self._geohash_arrow_table([2 ** 21], md=dict(padding)),
-                        table_name='geo_md_long', at='ts')['gh'],
-                    0x05)
+        # walks the values. Large metadata below the 1 MiB safety cap is
+        # handled natively and wide values are forwarded under the same
+        # unchecked contract.
+        padding = {f'pad.{i}'.encode(): b'x' for i in range(5000)}
+        md = dict(padding)
+        md[b'questdb.column_type'] = b'geohash'
+        md[b'questdb.geohash_bits'] = b'20'
+        self.assertEqual(
+            self._dataframe_column_types(
+                self._geohash_arrow_table([2 ** 21], md=md),
+                table_name='geo_md_long', at='ts')['gh'],
+            0x0E)
+        # A large allowed blob that claims nothing remains an ordinary
+        # integer column rather than a hidden geohash.
+        self.assertEqual(
+            self._dataframe_column_types(
+                self._geohash_arrow_table([2 ** 21], md=dict(padding)),
+                table_name='geo_md_long', at='ts')['gh'],
+            0x05)
+
+        # The native bounded parser rejects an individual blob above 1 MiB,
+        # independently of whether it carries a QuestDB type claim.
+        too_large = {b'pad.big': b'x' * (2 << 20)}
+        for claim in (False, True):
+            with self.subTest(above_blob_cap=True, claim=claim):
+                oversized = dict(too_large)
+                if claim:
+                    oversized[b'questdb.column_type'] = b'geohash'
+                    oversized[b'questdb.geohash_bits'] = b'20'
+                with self.assertRaisesRegex(
+                        qi.QuestDBError,
+                        r'Arrow schema root\.children\[0\]: metadata blob '
+                        r'exceeds 1048576 bytes'):
+                    self._dataframe_wire_payload(
+                        self._geohash_arrow_table([2 ** 21], md=oversized),
+                        table_name='geo_md_too_large', at='ts')
         # `schema_overrides` still outranks field metadata.
-        md = {f'pad.{i}'.encode(): b'x' for i in range(5000)}
+        md = dict(padding)
         md[b'questdb.column_type'] = b'geohash'
         md[b'questdb.geohash_bits'] = b'20'
         self._dataframe_wire_payload(

--- a/test/test_client_capsule_path.py
+++ b/test/test_client_capsule_path.py
@@ -7,6 +7,7 @@ DataFrame inputs to `QuestDB.dataframe()`.
 import sys
 sys.dont_write_bytecode = True
 import datetime
+import decimal
 import os
 import struct
 import unittest
@@ -47,6 +48,127 @@ def _ts_us(year, month, day, hour=0, minute=0, second=0):
     return int(datetime.datetime(
         year, month, day, hour, minute, second,
         tzinfo=datetime.timezone.utc).timestamp() * 1_000_000)
+
+
+# Physical layouts each pinned producer is expected to exercise. An explicit
+# "not emitted" is intentional: absence must be reviewed rather than silently
+# disappearing when a producer changes its export behavior.
+ARROW_PRODUCER_LAYOUT_MATRIX = {
+    'pyarrow': {
+        'fixed-width': 'emitted',
+        'variable-width': 'emitted',
+        'view': 'emitted by pyarrow 25',
+        'fixed-size-binary': 'emitted',
+        'list/large-list/fixed-size-list': 'emitted',
+        'dictionary': 'emitted',
+        'decimal': 'emitted',
+    },
+    'pandas': {
+        'fixed-width': 'emitted',
+        'variable-width': 'emitted',
+        'view': 'not emitted by the pinned pandas export',
+        'fixed-size-binary': 'not emitted by standard pandas dtypes',
+        'list/large-list/fixed-size-list': 'not emitted by stable pandas dtypes',
+        'dictionary': 'emitted by Categorical',
+        'decimal': 'not emitted by stable pandas dtypes',
+    },
+    'polars': {
+        'fixed-width': 'emitted',
+        'variable-width': 'emitted as Arrow view layouts',
+        'view': 'emitted',
+        'fixed-size-binary': 'not emitted; Polars Binary is variable-width',
+        'list/large-list/fixed-size-list': 'List and fixed Array emitted; LargeList not emitted',
+        'dictionary': 'not part of this pinned producer fixture',
+        'decimal': 'not part of this pinned producer fixture',
+    },
+}
+
+
+class TestArrowFfiProducerLayoutMatrix(unittest.TestCase):
+    def _assert_writes(self, frame, name):
+        with QwpAckServer(record_payloads=True) as server:
+            with qi.QuestDB.from_conf(_client_conf(server.port)) as client:
+                client.dataframe(
+                    frame, table_name=name, at=qi.ServerTimestamp,
+                    symbols=False)
+            self.assertGreaterEqual(server.wait_binary_frames_settled(), 1)
+            stats = server.snapshot()
+        self.assertEqual(stats['errors'], [])
+        self.assertGreaterEqual(stats['accepted_connections'], 1)
+        self.assertGreaterEqual(stats['qwp1_frames'], 1)
+
+    def test_matrix_has_no_implicit_omissions(self):
+        expected = {
+            'fixed-width', 'variable-width', 'view', 'fixed-size-binary',
+            'list/large-list/fixed-size-list', 'dictionary', 'decimal'}
+        self.assertEqual(set(ARROW_PRODUCER_LAYOUT_MATRIX), {
+            'pyarrow', 'pandas', 'polars'})
+        for producer, layouts in ARROW_PRODUCER_LAYOUT_MATRIX.items():
+            with self.subTest(producer=producer):
+                self.assertEqual(set(layouts), expected)
+                self.assertNotIn(None, layouts.values())
+
+    def test_ci_producer_versions_match_declared_pins(self):
+        pins = os.environ.get('TEST_QUESTDB_ARROW_PRODUCER_PINS')
+        if not pins:
+            self.skipTest('exact producer versions are asserted on the pinned CI leg')
+        installed = {
+            'pandas': pd.__version__,
+            'pyarrow': pa.__version__,
+            'polars': pl.__version__,
+        }
+        expected = dict(item.split('=', 1) for item in pins.split(','))
+        self.assertEqual(installed, expected)
+
+    @unittest.skipIf(pa is None, 'pyarrow not installed')
+    def test_pyarrow_emitted_layouts_pass_preflight(self):
+        columns = {
+            'i64': pa.array([1, 2], type=pa.int64()),
+            'flag': pa.array([True, False], type=pa.bool_()),
+            'stamp': pa.array([1, 2], type=pa.timestamp('us', tz='UTC')),
+            'text': pa.array(['alpha', 'beta'], type=pa.string()),
+            'large_text': pa.array(['alpha', 'beta'], type=pa.large_string()),
+            'blob': pa.array([b'a', b'b'], type=pa.binary()),
+            'fixed_blob': pa.array([b'abcd', b'efgh'], type=pa.binary(4)),
+            'list': pa.array([[1.0], [2.0, 3.0]], type=pa.list_(pa.float64())),
+            'large_list': pa.array(
+                [[1.0], [2.0, 3.0]], type=pa.large_list(pa.float64())),
+            'fixed_list': pa.array(
+                [[1.0, 2.0], [3.0, 4.0]], type=pa.list_(pa.float64(), 2)),
+            'category': pa.array(['a', 'b']).dictionary_encode(),
+            'decimal': pa.array(
+                [decimal.Decimal('1.25'), decimal.Decimal('2.50')],
+                type=pa.decimal128(12, 2)),
+        }
+        if hasattr(pa, 'string_view'):
+            columns['text_view'] = pa.array(['alpha', 'beta'], type=pa.string_view())
+            columns['binary_view'] = pa.array([b'a', b'b'], type=pa.binary_view())
+        self._assert_writes(pa.table(columns), 'arrow_layouts_pyarrow')
+
+    @unittest.skipIf(pd is None or pa is None, 'pandas/pyarrow not installed')
+    def test_pandas_categorical_dictionary_and_emitted_layouts_pass(self):
+        frame = pd.DataFrame({
+            'i64': pd.Series([1, 2], dtype='int64'),
+            'text': pd.Series(['alpha', 'beta'], dtype='string[pyarrow]'),
+            'category': pd.Categorical(['a', 'b']),
+        })
+        exported = pa.Table.from_pandas(frame, preserve_index=False)
+        self.assertTrue(pa.types.is_dictionary(exported.schema.field('category').type))
+        self._assert_writes(frame, 'arrow_layouts_pandas')
+
+    @unittest.skipIf(pl is None, 'polars not installed')
+    def test_polars_emitted_view_and_array_layouts_pass(self):
+        frame = pl.DataFrame({
+            'i64': pl.Series('i64', [1, 2], dtype=pl.Int64),
+            'text': pl.Series('text', ['alpha', 'beta'], dtype=pl.String),
+            'blob': pl.Series('blob', [b'a', b'b'], dtype=pl.Binary),
+            'list': pl.Series(
+                'list', [[1.0], [2.0, 3.0]], dtype=pl.List(pl.Float64)),
+            'fixed_list': pl.Series(
+                'fixed_list', [[1.0, 2.0], [3.0, 4.0]],
+                dtype=pl.Array(pl.Float64, 2)),
+        })
+        self._assert_writes(frame, 'arrow_layouts_polars')
 
 
 class TestCapsulePathPyArrow(unittest.TestCase):


### PR DESCRIPTION
## Summary

Completes the Stage 4 regression, producer-integration, and workflow-audit follow-up for the guarded Arrow 59 FFI model in #146.

This PR is intentionally based on `fix/arrow-ffi-hardening-model` at `c32d143187cd727f3e0f0c3a93d4fecfa3d750e4`. Its single commit is `27c254ff724bd0ab94c50e634f830776d407687a`.

The submodule is pinned exactly to `questdb/c-questdb-client@82096e6b5fcbd3c60b7ceb44ee658af546ce332e`, reviewed separately in questdb/c-questdb-client#198. That native PR is itself based on the Arrow 59 model in questdb/c-questdb-client#197; both dependencies must land before this PR.

## Changes

- expands the forged Arrow registry to 39 deterministic nested-schema/array cases;
- gives every registered case a declared success, `ArrowUnsupportedColumnKind`, or `ArrowIngest` outcome, stable path/invariant diagnostic, and wire/no-wire expectation;
- runs every case through `QuestDB.dataframe()` in a child process and asserts portable normal exit, exercised transport, exact no-wire behavior for rejections, and exact row/value encoding for the accepted end-boundary slice;
- adds real pyarrow, pandas, and Polars producer coverage beside an explicit emitted/not-emitted physical-layout matrix, including pandas Categorical → Arrow Dictionary success;
- adds a pinned producer leg using pandas 2.3.3, pyarrow 25.0.1, and Polars 1.44.1 while retaining range/latest coverage in the other legs;
- aligns legacy large-metadata tests with the 1 MiB per-distinct-blob contract, preserving below-cap positives and adding above-cap rejections;
- corrects the enumerated-grid header: scheduled runs do not enable Guard Malloc; only a manual `guard_malloc` dispatch does.

## Safety boundary

The guarded Python/C-ABI path rejects addressable malformed structural values before the known Arrow 59 panic paths covered by the native preflight. Producer-owned pointers and allocations must still be valid, correctly sized, stable, and NUL-terminated where required until release because the Arrow ABI does not expose their allocation lengths.

The arrow-rs nested-Struct issue is deliberately held pending explicit disclosure approval. The fully allocated local differential fixture remains the pinned regression gate.

## Validation

- complete Python suite: 1,014 passed, 28 skipped
- all 39 forged Arrow subprocess cases: passed
- pinned local producer-layout matrix: passed
- Python syntax, YAML parsing, and `git diff --check`: passed
- Arrow FFI lock guard: 11 Arrow-family packages at exactly 59.0.0
- native default FFI suite: 88 passed
- native all-feature FFI suite: 147 passed
- strict all-target/all-feature native Clippy: passed
- native formatting for both Rust crates: passed

The existing c-questdb-client C/C++ ASan+UBSan job does not execute the Rust FFI unit fixtures, and there is no Rust sanitizer job for them. The native differential fixtures are fully allocated, and the cross-platform CI/subprocess matrix supplies the deterministic process-survival coverage. No new Guard Malloc matrix was added.

## Deferred issues

- #147 — release a populated Arrow batch when `get_next` fails
- #148 — bound Arrow stream `get_last_error` decoding
- #149 — do not reuse one Arrow schema across separately exported slices
